### PR TITLE
Cluster post config aws region updates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -315,6 +315,18 @@ pipeline {
                 exit 1
               fi
             done
+            retries=0
+            while [[ $(oc get nodes -l 'node-role.kubernetes.io/workload=' --no-headers| wc -l) -lt 1 ]]; do
+              oc get nodes
+              oc get machines -A
+              oc get machinesets -A
+              sleep 30
+              ((retries += 1))
+              if [[ "${retries}" -gt ${attempts} ]]; then
+                echo "error: workload nodes didn't become READY in time, failing"
+                exit 1
+              fi
+            done
             oc get nodes
             oc label nodes --overwrite -l 'node-role.kubernetes.io/infra=' node-role.kubernetes.io/worker-
             oc label nodes --overwrite -l 'node-role.kubernetes.io/workload=' node-role.kubernetes.io/worker-

--- a/workload-node-machineset-aws.yaml
+++ b/workload-node-machineset-aws.yaml
@@ -6,7 +6,7 @@ metadata:
     ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-cluster: ${CLUSTER_NAME}
     ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-role: workload
     ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-type: workload
-  name: workload-${CLUSTER_REGION}d
+  name: workload-${CLUSTER_REGION}a
   namespace: openshift-machine-api
 spec:
   replicas: 1
@@ -47,7 +47,7 @@ spec:
           metadata:
             creationTimestamp: null
           placement:
-            availabilityZone: ${CLUSTER_REGION}d
+            availabilityZone: ${CLUSTER_REGION}a
             region: ${CLUSTER_REGION}
           publicIp: true
           securityGroups:
@@ -59,7 +59,7 @@ spec:
             filters:
             - name: tag:Name
               values:
-              - ${CLUSTER_NAME}-public-${CLUSTER_REGION}d
+              - ${CLUSTER_NAME}-private-${CLUSTER_REGION}a
           tags:
           - name: kubernetes.io/cluster/${CLUSTER_NAME}
             value: owned


### PR DESCRIPTION
Adding in zone a instead of d. This was not working for me on the openshift-qe aws account. Also changing to private security group. Using the public group the workload node never would become running 