### PR TITLE
Cluster workers scaling -- Missed one hard set 3 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
               oc scale machinesets -n openshift-machine-api $machineset --replicas $scale_size
           done
           if [[ $(($1%$scale_num)) != 0 ]]; then
-            oc scale machinesets -n openshift-machine-api  $(oc get --no-headers machinesets -A | awk '{print $2}' | head -1) --replicas $(($scale_size+$(($1%3))))
+            oc scale machinesets -n openshift-machine-api  $(oc get --no-headers machinesets -A | awk '{print $2}' | head -1) --replicas $(($scale_size+$(($1%$scale_num))))
           fi
           set +x
           local retries=0


### PR DESCRIPTION
Had an issue the other day that the counting was off for the number of workers that were created in each of the machinesets
 
Noticed that there is still one hard set 3 on one line 