### PR TITLE
Move virtualenv to /usr/bin after install

### DIFF
--- a/prow/Dockerfile
+++ b/prow/Dockerfile
@@ -3,4 +3,4 @@ FROM quay.io/fedora/fedora:34
 LABEL vendor="Red Hat Inc." maintainer="OCP QE Team"
 
 RUN dnf -y install python3-pip && curl -sSL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz |  tar  -xvzf  - oc && \
-    mv oc /bin && /usr/bin/python3 -m pip install --upgrade pip &&  python3 -m pip install virtualenv --user 
+    mv oc /bin && /usr/bin/python3 -m pip install --upgrade pip &&  python3 -m pip install virtualenv --user && mv /root/.local/bin/virtualenv /bin/. 


### PR DESCRIPTION
Prow CI is not finding virtualenv in /root/.local/bin in the image.   Move it to /usr/bin.