### PR TITLE
Fixing names of infra machinesets, network, adding region for GCP

### DIFF
--- a/infra-node-machineset-gcp.yaml
+++ b/infra-node-machineset-gcp.yaml
@@ -48,8 +48,8 @@ items:
             metadata:
               creationTimestamp: null
             networkInterfaces:
-            - network: ${CLUSTER_NAME}-network
-              subnetwork: ${CLUSTER_NAME}-worker-subnet
+            - network: ${NETWORK_NAME}
+              subnetwork: ${SUBNET_NETWORK_NAME}
             projectID: ${GCP_PROJECT}
             region: ${GCP_REGION}
             serviceAccounts:
@@ -69,7 +69,7 @@ items:
     generation: 1
     labels:
       ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-cluster: ${CLUSTER_NAME}
-    name: infra-b
+    name: infra-${CLUSTER_NAME}b
     namespace: openshift-machine-api
   spec:
     replicas: 1
@@ -111,8 +111,8 @@ items:
             metadata:
               creationTimestamp: null
             networkInterfaces:
-            - network: ${CLUSTER_NAME}-network
-              subnetwork: ${CLUSTER_NAME}-worker-subnet
+            - network: ${NETWORK_NAME}
+              subnetwork: ${SUBNET_NETWORK_NAME}
             projectID: ${GCP_PROJECT}
             region: ${GCP_REGION}
             serviceAccounts:
@@ -132,7 +132,7 @@ items:
     generation: 1
     labels:
       ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-cluster: ${CLUSTER_NAME}
-    name: infra-c
+    name: infra-${CLUSTER_NAME}c
     namespace: openshift-machine-api
   spec:
     replicas: 1
@@ -174,8 +174,8 @@ items:
             metadata:
               creationTimestamp: null
             networkInterfaces:
-            - network: ${CLUSTER_NAME}-network
-              subnetwork: ${CLUSTER_NAME}-worker-subnet
+            - network: ${NETWORK_NAME}
+              subnetwork: ${SUBNET_NETWORK_NAME}
             projectID: ${GCP_PROJECT}
             region: ${GCP_REGION}
             serviceAccounts:

--- a/workload-node-machineset-gcp.yaml
+++ b/workload-node-machineset-gcp.yaml
@@ -46,8 +46,8 @@ spec:
           metadata:
             creationTimestamp: null
           networkInterfaces:
-          - network: ${CLUSTER_NAME}-network
-            subnetwork: ${CLUSTER_NAME}-worker-subnet
+          - network: ${NETWORK_NAME}
+            subnetwork: ${SUBNET_NETWORK_NAME}
             publicIP: true
           projectID: ${GCP_PROJECT}
           region: ${GCP_REGION}


### PR DESCRIPTION
Changes in this PR specifically for GCP:
* Fixed all infra machinesets to have cluster name in them 
* Install dir was not able to be found, used env variable (VARIABLES_LOCATION) instead to find type of cloud provider
* Network sometimes was a truncated version of the cluster name was not able to be found
* Similar to network, the subnet could be truncated 
* If just adding the infra nodes portion of this Jenkinsfile, needed to get the correct network
* Added a way to dynamically get the region that the cluster is in
* Service account email did not exist with the name that was shown so infra and workload nodes would fail to create


Fixes: https://github.com/openshift-qe/ocp-qe-perfscale-ci/issues/38