### PR TITLE
Remove pip3 install of requirements.txt - hostnetwork

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,7 +112,6 @@ pipeline {
             source venv3/bin/activate
             python --version
             cd ..
-            pip3 install -r requirements.txt
             ./run_hostnetwork_network_test_fromgit.sh
             rm -rf ~/.kube
             '''


### PR DESCRIPTION
Remove pip install - no longer necessary due to e2e-benchmark changes