### PR TITLE
Removing installation of requirements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,7 +87,6 @@ pipeline {
             ls -ls ~/.kube/
             env
             cd workloads/network-perf
-            pip3 install -r requirements.txt
             ./run_pod_network_policy_test_fromgit.sh
             rm -rf ~/.kube
             '''


### PR DESCRIPTION
Requirements were removed from https://github.com/cloud-bulldozer/e2e-benchmarking/tree/master/workloads/network-perf repository.
Missing this file is making jenkins dizzy :)