### PR TITLE
Adding missing condition for flexy-destroy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -254,18 +254,15 @@ REG_SVC_CI=9a9187c6-a54c-452a-866f-bea36caea6f9''' ) ]
             agent { label params['JENKINS_AGENT_LABEL'] }
             steps{
                 script{
-                if ( install != null ) {
-                    if( install.result.toString() != "SUCCESS" ) {
+                    if(install != null && (install.result.toString() != "SUCCESS" || params.DESTROY_WHEN_DONE == true)) {
                         destroy_ci = build job: 'ocp-common/Flexy-destroy', parameters: [string(name: "BUILD_NUMBER", value: install.number.toString()),string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL)]
                     }
+                    if(install == null && params.DESTROY_WHEN_DONE == true) {
+                        destroy_ci = build job: 'ocp-common/Flexy-destroy', parameters: [string(name: "BUILD_NUMBER", value: build_string),string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL)]
+                    }
                 }
-                if (params.DESTROY_WHEN_DONE == true){
-                    destroy_ci = build job: 'ocp-common/Flexy-destroy', parameters: [string(name: "BUILD_NUMBER", value: build_string),string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL)]
-                }
-
-             }
-         }
-         }
+            }
+        }
         stage('Setting Proper Status'){
             agent { label params['JENKINS_AGENT_LABEL'] }
             steps{

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -256,8 +256,7 @@ REG_SVC_CI=9a9187c6-a54c-452a-866f-bea36caea6f9''' ) ]
                 script{
                     if(install != null && (install.result.toString() != "SUCCESS" || params.DESTROY_WHEN_DONE == true)) {
                         destroy_ci = build job: 'ocp-common/Flexy-destroy', parameters: [string(name: "BUILD_NUMBER", value: install.number.toString()),string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL)]
-                    }
-                    if(install == null && params.DESTROY_WHEN_DONE == true) {
+                    } else if(install == null && params.DESTROY_WHEN_DONE == true) {
                         destroy_ci = build job: 'ocp-common/Flexy-destroy', parameters: [string(name: "BUILD_NUMBER", value: build_string),string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL)]
                     }
                 }


### PR DESCRIPTION
When flexy-install was provided by loaded-upgrade build and cluster was marked: DESTROY_WHEN_DONE, then jenkins was running two flexy-destroy jobs. ex. https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/loaded-upgrade/189/console