### PR TITLE
EUS upgrade type

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,7 @@ if (userId) {
 
 def overall_status = "FAIL"
 def RETURNSTATUS = "default"
+
 pipeline {
   agent none
 
@@ -27,6 +28,9 @@ pipeline {
         string(name: 'UPGRADE_VERSION', description: 'This variable sets the version number you want to upgrade your OpenShift cluster to.')
         booleanParam(name: 'ENABLE_FORCE', defaultValue: true, description: 'This variable will force the upgrade or not')
         booleanParam(name: 'SCALE', defaultValue: false, description: 'This variable will scale the cluster up one node at the end up the ugprade')
+        booleanParam(name: 'EUS_UPGRADE', defaultValue: false, description: '''This variable will perform an EUS type upgrade <br>
+        See "https://docs.google.com/document/d/1396VAUFLmhj8ePt9NfJl0mfHD7pUT7ii30AO7jhDp0g/edit#heading=h.bv3v69eaalsw" for how to run
+        ''')
         string(name: 'MAX_UNAVAILABLE', defaultValue: "1", description: 'This variable will set the max number of unavailable nodes during the upgrade')
         booleanParam(name: 'WRITE_TO_FILE', defaultValue: true, description: 'Value to write to google sheet ')
         text(name: 'ENV_VARS', defaultValue: '', description:'''<p>
@@ -65,8 +69,8 @@ pipeline {
           currentBuild.description = "Copying Artifact from Flexy-install build <a href=\"${buildinfo.buildUrl}\">Flexy-install#${params.BUILD_NUMBER}</a>"
           buildinfo.params.each { env.setProperty(it.key, it.value) }
         }
-        script {
 
+        script {
           RETURNSTATUS = sh(returnStatus: true, script: '''
           # Get ENV VARS Supplied by the user to this job and store in .env_override
           echo "$ENV_VARS" > .env_override
@@ -86,7 +90,7 @@ pipeline {
           pip --version
           pip install --upgrade pip
           pip install -U datetime pyyaml
-          ./upgrade.sh $UPGRADE_VERSION -f $ENABLE_FORCE -s $SCALE -u $MAX_UNAVAILABLE
+          ./upgrade.sh $UPGRADE_VERSION -f $ENABLE_FORCE -s $SCALE -u $MAX_UNAVAILABLE -e $EUS_UPGRADE
           ''' )
            }
            script {
@@ -107,5 +111,5 @@ pipeline {
             }
         }
      }
-
 }
+

--- a/upgrade_scripts/check_upgrade.py
+++ b/upgrade_scripts/check_upgrade.py
@@ -4,7 +4,7 @@ import time
 import yaml
 import subprocess
 import sys
-
+import json
 
 # Invokes a given command and returns the stdout
 def invoke(command):
@@ -15,13 +15,91 @@ def invoke(command):
         return exc.returncode, exc.output
     return 0, output
 
-
 def set_max_unavailable(maxUnavailable):
 
     merge_json = '{"spec":{"maxUnavailable": %d }}' % maxUnavailable
     return_code, output = invoke(f"oc patch machineconfigpool/worker --type='merge' -p='{merge_json}'")
     if return_code != 0:
         print("Error occurred trying to set maxUnavialble nodes")
+
+def get_sha_url(url,version):
+    return_code, output = invoke("curl " + url)
+    json_output = json.loads(output)
+    for version_json in json_output['nodes']:
+        if version_json['version'] == version:
+            print(version_json['payload'])
+            return
+    print("")
+
+def set_upstream_channel(version):
+
+    small_version = ".".join(version.split('.', 2)[:2])
+    print('small v ' + str(small_version))
+    if small_version == "4.9":
+        patch_48_to_49()
+    merge_json = '{"spec":{"channel": "fast-%s" }}' % small_version
+    return_code, output = invoke(f"oc patch clusterversion/version --type='merge' -p='{merge_json}'")
+    if return_code != 0:
+        print("Error occurred trying to patch channel version")
+    print('output ' + str(output))
+    return_code, output = invoke("oc get clusterversion -ojson|jq .items[].spec")
+    print('output ' + str(output))
+
+def patch_48_to_49():
+    merge_json = '{"data":{"ack-4.8-kube-1.22-api-removals-in-4.9":"true"}}'
+    print('patch api')
+    return_code, output = invoke(f"oc -n openshift-config patch cm admin-acks --type=merge -p='{merge_json}'")
+    print('output: ' + str(output))
+
+def set_upstream_url(url):
+
+    merge_json = '{"spec":{"upstream": "%s" }}' % url
+    return_code, output = invoke(f"oc patch clusterversion/version --type='merge' -p='{merge_json}'")
+    if return_code != 0:
+        print("Error occurred trying to patch channel url")
+    print('output ' + str(output))
+
+def verify_version_in_channel_list(expected_version):
+    return_code, output = invoke("oc adm upgrade")
+    if return_code != 0:
+        print("ERROR")
+
+    split_output = output.split("Recommended updates")
+    new_line_output = split_output[-1].split('\n')
+    for line in new_line_output:
+        space_line = line.split('   ')[0]
+        if expected_version == space_line.strip():
+            print('expected version in list')
+            return
+    print("ERROR")
+
+def get_upgrade_status(mcp_json):
+    for mcp_status in mcp_json['status']['conditions']:
+        if mcp_status['type'] == "Updating":
+            return mcp_status['status']
+
+def wait_for_mcp_upgrade(wait_num=90):
+    counter = 0
+    return_code, worker_str = invoke(f"oc get mcp worker -o json")
+    worker_json = json.loads(worker_str)
+    while get_upgrade_status(worker_json) != "False":
+        time.sleep(20)
+        return_code, worker_str = invoke(f"oc get mcp worker -o json")
+        worker_json = json.loads(worker_str)
+        print("MCP workers are updating, waiting 20 seconds")
+        counter += 1
+        if counter >= wait_num:
+            return_code, node_not_ready = invoke("oc get nodes | grep 'NotReady\|SchedulingDisabled'")
+            print("Node list: " + str(node_not_ready))
+            print("ERROR, mcp workers are still updating after 30 minutes")
+            sys.exit(1)
+
+def pause_machinepool_worker(pause_val):
+    merge_json = '{"spec":{"paused": %s }}' % pause_val
+    return_code, output = invoke(f"oc patch --type=merge --patch='{merge_json}' machineconfigpool/worker")
+    if return_code != 0:
+        print("Error occurred trying to pause machineconfigpool/worker")
+    print('output ' + str(output))
 
 def check_cluster_version():
 


### PR DESCRIPTION
Adding in flag to do Eus upgrade type

Pause the mcp worker 
"oc patch mcp/worker --type merge --patch '{"spec":{"paused":true}}'"

Set the channel to fast-4.<number>

oc adm upgrade --to 4.<number>.<number>

Unpause workers (after all upgrades complete)
oc patch mcp/worker --type merge --patch '{"spec":{"paused":false}}'

Version number must be in the list of recommended paths when callin `oc adm upgrade`
Or will print `Could not find target version 4.<version_num> in 'oc adm upgrade' recommended paths
` and exit