### PR TITLE
Adding alibaba starting for infra or workload nodes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,6 +73,18 @@ pipeline {
                OPENSHIFT_WORKLOAD_NODE_MEMORY_SIZE=131072<br>
                OPENSHIFT_WORKLOAD_NODE_CPU_CORE_PER_SOCKET_COUNT=2<br>
                OPENSHIFT_WORKLOAD_NODE_NETWORK_NAME=qe-segment<br>
+               e.g. <b>for Alicloud:</b><br>
+               OPENSHIFT_INFRA_NODE_VOLUME_SIZE=100 <br>
+               OPENSHIFT_INFRA_NODE_INSTANCE_TYPE=ecs.g6.13xlarge <br>
+               OPENSHIFT_WORKLOAD_NODE_VOLUME_SIZE=500 <br>
+               OPENSHIFT_WORKLOAD_NODE_INSTANCE_TYPE=ecs.g6.8xlarge <br>
+               OPENSHIFT_PROMETHEUS_STORAGE_CLASS=alicloud-disk <br>
+               OPENSHIFT_ALERTMANAGER_STORAGE_CLASS=alicloud-disk <br>
+               e.g. <b>for Ibmcloud:</b><br>
+               OPENSHIFT_INFRA_NODE_INSTANCE_TYPE=bx2d-48x192<br>
+               OPENSHIFT_WORKLOAD_NODE_INSTANCE_TYPE=bx2-32x128<br>
+               OPENSHIFT_PROMETHEUS_STORAGE_CLASS=ibmc-vpc-block-5iops-tier<br>
+               OPENSHIFT_ALERTMANAGER_STORAGE_CLASS=ibmc-vpc-block-5iops-tier<br>
                <b>And ALWAYS INCLUDE(except for vSphere provider) this part, for Prometheus AlertManager, it may look like</b>:<br>
                OPENSHIFT_PROMETHEUS_RETENTION_PERIOD=15d<br>
                OPENSHIFT_PROMETHEUS_STORAGE_SIZE=500Gi  <br>
@@ -105,9 +117,12 @@ pipeline {
                          file(credentialsId: 'ocp-azure', variable: 'OCP_AZURE')]) {
           sh label: '', script: '''
           if [[ $HOST_NETWORK_CONFIGS == "true" ]]; then
+            # Get ENV VARS Supplied by the user to this job and store in .env_override
+            echo "$ENV_VARS" > .env_override
+            # Export those env vars so they could be used by CI Job
+            set -a && source .env_override && set +a
             mkdir -p ~/.kube
             cp $WORKSPACE/flexy-artifacts/workdir/install-dir/auth/kubeconfig ~/.kube/config
-
             oc config view
             oc projects
             ls -ls ~/.kube/
@@ -277,16 +292,12 @@ pipeline {
               export CLUSTER_REGION=$(oc get machineset -n openshift-machine-api -o=go-template='{{(index .items 0).spec.template.spec.providerSpec.value.placement.region}}')
               envsubst < infra-node-machineset-aws.yaml | oc apply -f -
               envsubst < workload-node-machineset-aws.yaml | oc apply -f -
-            fi
-
-            if [[ $(echo $VARIABLES_LOCATION | grep azure -c) > 0 ]]; then
+            elif [[ $(echo $VARIABLES_LOCATION | grep azure -c) > 0 ]]; then
               export AMI_ID=$(oc get machineset -n openshift-machine-api -o=go-template='{{(index .items 0).spec.template.spec.providerSpec.value.ami.id}}')
               export AZURE_LOCATION=$(oc get machineset -n openshift-machine-api -o=go-template='{{(index .items 0).spec.template.spec.providerSpec.value.location}}')
               envsubst < infra-node-machineset-azure.yaml | oc apply -f -
               envsubst < workload-node-machineset-azure.yaml | oc apply -f -
-            fi
-
-            if [[ $(echo $VARIABLES_LOCATION | grep gcp -c) > 0 ]]; then
+            elif [[ $(echo $VARIABLES_LOCATION | grep gcp -c) > 0 ]]; then
 
               echo $NETWORK_NAME
               # login to service account
@@ -311,9 +322,7 @@ pipeline {
               oc apply -f gcp-sc-pd-ssd.yaml
               envsubst < infra-node-machineset-gcp.yaml | oc apply -f -
               envsubst < workload-node-machineset-gcp.yaml | oc apply -f -
-            fi
-
-            if [[ $(echo $VARIABLES_LOCATION | grep vsphere -c) > 0 ]]; then
+            elif [[ $(echo $VARIABLES_LOCATION | grep vsphere -c) > 0 ]]; then
               export WORKER_NODE_MACHINESET=$(oc get machinesets --no-headers -n openshift-machine-api | awk {'print $1'} | awk 'NR==1{print $1}')
               export WORKER_MACHINESET_IMAGE=$(oc get machineset ${WORKER_NODE_MACHINESET} -n openshift-machine-api -o jsonpath='{.spec.template.spec.providerSpec.value.disks[0].image}')
               export TEMPLATE_NAME=$(oc get machineset -n openshift-machine-api $(oc get machinesets --no-headers -A -o custom-columns=:.metadata.name | head -1) -o=jsonpath='{.spec.template.spec.providerSpec.value.template}')
@@ -324,8 +333,21 @@ pipeline {
               export VSPHERE_SERVER=$(oc get machineset -n openshift-machine-api $(oc get machinesets --no-headers -A -o custom-columns=:.metadata.name | head -1) -o=jsonpath='{.spec.template.spec.providerSpec.value.workspace.server}')
               envsubst < infra-node-machineset-vsphere.yaml | oc apply -f -
               envsubst < workload-node-machineset-vsphere.yaml | oc apply -f -
-            fi
+            elif [[ $(echo $VARIABLES_LOCATION | grep alicloud -c) > 0 ]]; then
+              export WORKER_NODE_MACHINESET=$(oc get machinesets --no-headers -n openshift-machine-api | awk {'print $1'} | awk 'NR==1{print $1}')
+              export WORKER_MACHINESET_IMAGE=$(oc get machineset ${WORKER_NODE_MACHINESET} -n openshift-machine-api -o jsonpath='{.spec.template.spec.providerSpec.value.imageId}')
+              export CLUSTER_REGION=$(oc get machineset -n openshift-machine-api -o=go-template='{{(index .items 0).spec.template.spec.providerSpec.value.regionId}}')
 
+              envsubst < infra-node-machineset-alicloud.yaml | oc apply -f -
+              envsubst < workload-node-machineset-alicloud.yaml | oc apply -f -
+
+            elif [[ $(echo $VARIABLES_LOCATION | grep ibmcloud -c) > 0 ]]; then
+              export WORKER_NODE_MACHINESET=$(oc get machinesets --no-headers -n openshift-machine-api | awk {'print $1'} | awk 'NR==1{print $1}')
+              export CLUSTER_REGION=$(oc get machineset -n openshift-machine-api -o=go-template='{{(index .items 0).spec.template.spec.providerSpec.value.region}}')
+              envsubst < infra-node-machineset-ibmcloud.yaml | oc apply -f -
+              envsubst < workload-node-machineset-ibmcloud.yaml | oc apply -f -
+
+            fi
             retries=0
             attempts=60
             while [[ $(oc get nodes -l 'node-role.kubernetes.io/infra=' --no-headers| wc -l) -lt 3 ]]; do

--- a/README.md
+++ b/README.md
@@ -5,5 +5,13 @@
 A job that will allow adding and removing firewall ports for HostNetwork Uperf testing. Can be extended to do other operations. To be called after fresh Flexy-cluster is created. And then call again before flexy-destroy to revert any changes made to the cluster.
 
 
+## Current supported cloud cluster types
+* AWS
+* Azure
+* GCP
+* Vsphere
+* Alicloud/Alibaba (only infra nodes)
+* IBM Cloud (only infra nodes)
+
 ### Author
-Kedar Kulkarni <@kedark3 on Github>
+Paige Rubendall <@paigerube14 on Github>

--- a/infra-node-machineset-alicloud.yaml
+++ b/infra-node-machineset-alicloud.yaml
@@ -1,0 +1,160 @@
+apiVersion: v1
+kind: List
+metadata: {}
+items:
+- apiVersion: machine.openshift.io/v1beta1
+  kind: MachineSet
+  metadata:
+    labels:
+      machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+      machine.openshift.io/cluster-api-machine-role: infra
+      machine.openshift.io/cluster-api-machine-type: infra
+    name: infra-${CLUSTER_REGION}-a
+    namespace: openshift-machine-api
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+        machine.openshift.io/cluster-api-machineset: infra-${CLUSTER_REGION}a
+    template:
+      metadata:
+        labels:
+          machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+          machine.openshift.io/cluster-api-machine-role: infra
+          machine.openshift.io/cluster-api-machine-type: infra
+          machine.openshift.io/cluster-api-machineset: infra-${CLUSTER_REGION}a
+      spec:
+        metadata:
+          labels:
+            node-role.kubernetes.io/infra: ""
+        providerSpec:
+          value:
+            apiVersion: machine.openshift.io/v1
+            credentialsSecret:
+              name: alibabacloud-credentials
+            imageId: ${WORKER_MACHINESET_IMAGE}
+            instanceType: ${OPENSHIFT_INFRA_NODE_INSTANCE_TYPE}
+            kind: AlibabaCloudMachineProviderConfig
+            ramRoleName: ${CLUSTER_NAME}-role-worker
+            regionId: ${CLUSTER_REGION}
+            resourceGroup:
+              name: ${CLUSTER_NAME}-rg
+              type: Name
+            securityGroups:
+            - tags:
+              - Key: kubernetes.io/cluster/${CLUSTER_NAME}
+                Value: owned
+              - Key: GISV
+                Value: ocp
+              - Key: sigs.k8s.io/cloud-provider-alibaba/origin
+                Value: ocp
+              - Key: Name
+                Value: ${CLUSTER_NAME}-sg-worker
+              type: Tags
+            systemDisk:
+              category: cloud_essd
+              size: ${OPENSHIFT_INFRA_NODE_VOLUME_SIZE}
+            tag:
+            - Key: kubernetes.io/cluster/${CLUSTER_NAME}
+              Value: owned
+            - Key: GISV
+              Value: ocp
+            - Key: sigs.k8s.io/cloud-provider-alibaba/origin
+              Value: ocp
+            userDataSecret:
+              name: worker-user-data
+            vSwitch:
+              tags:
+              - Key: kubernetes.io/cluster/${CLUSTER_NAME}
+                Value: owned
+              - Key: GISV
+                Value: ocp
+              - Key: sigs.k8s.io/cloud-provider-alibaba/origin
+                Value: ocp
+              - Key: Name
+                Value: ${CLUSTER_NAME}-vswitch-${CLUSTER_REGION}a
+              type: Tags
+            vpcId: ""
+            zoneId: ${CLUSTER_REGION}a
+          taints:
+          - key: node-role.kubernetes.io/infra
+            effect: NoSchedule
+- apiVersion: machine.openshift.io/v1beta1
+  kind: MachineSet
+  metadata:
+    labels:
+      machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+      machine.openshift.io/cluster-api-machine-role: infra
+      machine.openshift.io/cluster-api-machine-type: infra
+    name: infra-${CLUSTER_REGION}-b
+    namespace: openshift-machine-api
+  spec:
+    replicas: 2
+    selector:
+      matchLabels:
+        machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+        machine.openshift.io/cluster-api-machineset: infra-${CLUSTER_REGION}b
+    template:
+      metadata:
+        labels:
+          machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+          machine.openshift.io/cluster-api-machine-role: infra
+          machine.openshift.io/cluster-api-machine-type: infra
+          machine.openshift.io/cluster-api-machineset: infra-${CLUSTER_REGION}b
+      spec:
+        metadata:
+          labels:
+            node-role.kubernetes.io/infra: ""
+        providerSpec:
+          value:
+            apiVersion: machine.openshift.io/v1
+            credentialsSecret:
+              name: alibabacloud-credentials
+            imageId: ${WORKER_MACHINESET_IMAGE}
+            instanceType: ${OPENSHIFT_INFRA_NODE_INSTANCE_TYPE}
+            kind: AlibabaCloudMachineProviderConfig
+            ramRoleName: ${CLUSTER_NAME}-role-worker
+            regionId: ${CLUSTER_REGION}
+            resourceGroup:
+              name: ${CLUSTER_NAME}-rg
+              type: Name
+            securityGroups:
+            - tags:
+              - Key: kubernetes.io/cluster/${CLUSTER_NAME}
+                Value: owned
+              - Key: GISV
+                Value: ocp
+              - Key: sigs.k8s.io/cloud-provider-alibaba/origin
+                Value: ocp
+              - Key: Name
+                Value: ${CLUSTER_NAME}-sg-worker
+              type: Tags
+            systemDisk:
+              category: cloud_essd
+              size: ${OPENSHIFT_INFRA_NODE_VOLUME_SIZE}
+            tag:
+            - Key: kubernetes.io/cluster/${CLUSTER_NAME}
+              Value: owned
+            - Key: GISV
+              Value: ocp
+            - Key: sigs.k8s.io/cloud-provider-alibaba/origin
+              Value: ocp
+            userDataSecret:
+              name: worker-user-data
+            vSwitch:
+              tags:
+              - Key: kubernetes.io/cluster/${CLUSTER_NAME}
+                Value: owned
+              - Key: GISV
+                Value: ocp
+              - Key: sigs.k8s.io/cloud-provider-alibaba/origin
+                Value: ocp
+              - Key: Name
+                Value: ${CLUSTER_NAME}-vswitch-${CLUSTER_REGION}b
+              type: Tags
+            vpcId: ""
+            zoneId: ${CLUSTER_REGION}b
+          taints:
+          - key: node-role.kubernetes.io/infra
+            effect: NoSchedule

--- a/infra-node-machineset-ibmcloud.yaml
+++ b/infra-node-machineset-ibmcloud.yaml
@@ -1,0 +1,148 @@
+apiVersion: v1
+kind: List
+metadata: {}
+items:
+- apiVersion: machine.openshift.io/v1beta1
+  kind: MachineSet
+  metadata:
+    labels:
+      machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+      machine.openshift.io/cluster-api-machine-role: infra
+      machine.openshift.io/cluster-api-machine-type: infra
+    name: ${CLUSTER_NAME}-infra-1
+    namespace: openshift-machine-api
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+        machine.openshift.io/cluster-api-machineset: ${CLUSTER_NAME}-infra-${CLUSTER_REGION}
+    template:
+      metadata:
+        labels:
+          machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+          machine.openshift.io/cluster-api-machine-role: infra
+          machine.openshift.io/cluster-api-machine-type: infra
+          machine.openshift.io/cluster-api-machineset: ${CLUSTER_NAME}-infra-${CLUSTER_REGION}
+      spec:
+        metadata:
+          labels:
+            node-role.kubernetes.io/infra: ''
+        providerSpec:
+          value:
+            apiVersion: ibmcloudproviderconfig.openshift.io/v1beta1
+            credentialsSecret:
+              name: ibmcloud-credentials
+            image: ${CLUSTER_NAME}-rhcos
+            kind: IBMCloudMachineProviderSpec
+            primaryNetworkInterface:
+              securityGroups:
+                - ${CLUSTER_NAME}-sg-cluster-wide
+                - ${CLUSTER_NAME}-sg-openshift-net
+              subnet: ${CLUSTER_NAME}-subnet-compute-${CLUSTER_REGION}-1
+            profile: ${OPENSHIFT_INFRA_NODE_INSTANCE_TYPE}
+            region: ${CLUSTER_REGION}
+            resourceGroup: ${CLUSTER_NAME}
+            userDataSecret:
+              name: worker-user-data
+            vpc: ${CLUSTER_NAME}-vpc
+            zone: ${CLUSTER_REGION}-1
+          taints:
+            - key: node-role.kubernetes.io/infra
+              effect: NoSchedule
+- apiVersion: machine.openshift.io/v1beta1
+  kind: MachineSet
+  metadata:
+    labels:
+      machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+      machine.openshift.io/cluster-api-machine-role: infra
+      machine.openshift.io/cluster-api-machine-type: infra
+    name: ${CLUSTER_NAME}-infra-2
+    namespace: openshift-machine-api
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+        machine.openshift.io/cluster-api-machineset: '${CLUSTER_NAME}-infra-${CLUSTER_REGION}'
+    template:
+      metadata:
+        labels:
+          machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+          machine.openshift.io/cluster-api-machine-role: infra
+          machine.openshift.io/cluster-api-machine-type: infra
+          machine.openshift.io/cluster-api-machineset: '${CLUSTER_NAME}-infra-${CLUSTER_REGION}'
+      spec:
+        metadata:
+          labels:
+            node-role.kubernetes.io/infra: ''
+        providerSpec:
+          value:
+            apiVersion: ibmcloudproviderconfig.openshift.io/v1beta1
+            credentialsSecret:
+              name: ibmcloud-credentials
+            image: '${CLUSTER_NAME}-rhcos'
+            kind: IBMCloudMachineProviderSpec
+            primaryNetworkInterface:
+              securityGroups:
+                - '${CLUSTER_NAME}-sg-cluster-wide'
+                - '${CLUSTER_NAME}-sg-openshift-net'
+              subnet: '${CLUSTER_NAME}-subnet-compute-${CLUSTER_REGION}-2'
+            profile: '${OPENSHIFT_INFRA_NODE_INSTANCE_TYPE}'
+            region: '${CLUSTER_REGION}'
+            resourceGroup: ${CLUSTER_NAME}
+            userDataSecret:
+              name: worker-user-data
+            vpc: '${CLUSTER_NAME}-vpc'
+            zone: '${CLUSTER_REGION}-2'
+          taints:
+            - key: node-role.kubernetes.io/infra
+              effect: NoSchedule
+- apiVersion: machine.openshift.io/v1beta1
+  kind: MachineSet
+  metadata:
+    labels:
+      machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+      machine.openshift.io/cluster-api-machine-role: infra
+      machine.openshift.io/cluster-api-machine-type: infra
+    name: '${CLUSTER_NAME}-infra-3'
+    namespace: openshift-machine-api
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+        machine.openshift.io/cluster-api-machineset: '${CLUSTER_NAME}-infra-${CLUSTER_REGION}'
+    template:
+      metadata:
+        labels:
+          machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+          machine.openshift.io/cluster-api-machine-role: infra
+          machine.openshift.io/cluster-api-machine-type: infra
+          machine.openshift.io/cluster-api-machineset: '${CLUSTER_NAME}-infra-${CLUSTER_REGION}'
+      spec:
+        metadata:
+          labels:
+            node-role.kubernetes.io/infra: ''
+        providerSpec:
+          value:
+            apiVersion: ibmcloudproviderconfig.openshift.io/v1beta1
+            credentialsSecret:
+              name: ibmcloud-credentials
+            image: '${CLUSTER_NAME}-rhcos'
+            kind: IBMCloudMachineProviderSpec
+            primaryNetworkInterface:
+              securityGroups:
+                - '${CLUSTER_NAME}-sg-cluster-wide'
+                - '${CLUSTER_NAME}-sg-openshift-net'
+              subnet: '${CLUSTER_NAME}-subnet-compute-${CLUSTER_REGION}-3'
+            profile: '${OPENSHIFT_INFRA_NODE_INSTANCE_TYPE}'
+            region: '${CLUSTER_REGION}'
+            resourceGroup: ${CLUSTER_NAME}
+            userDataSecret:
+              name: worker-user-data
+            vpc: '${CLUSTER_NAME}-vpc'
+            zone: '${CLUSTER_REGION}-3'
+          taints:
+            - key: node-role.kubernetes.io/infra
+              effect: NoSchedule

--- a/workload-node-machineset-alicloud.yaml
+++ b/workload-node-machineset-alicloud.yaml
@@ -1,0 +1,78 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+    machine.openshift.io/cluster-api-machine-role: workload
+    machine.openshift.io/cluster-api-machine-type: workload
+  name: workload-${CLUSTER_REGION}-a
+  namespace: openshift-machine-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+      machine.openshift.io/cluster-api-machineset: workload-${CLUSTER_REGION}a
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+        machine.openshift.io/cluster-api-machine-role: workload
+        machine.openshift.io/cluster-api-machine-type: workload
+        machine.openshift.io/cluster-api-machineset: workload-${CLUSTER_REGION}a
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/workload: ""
+      providerSpec:
+        value:
+          apiVersion: machine.openshift.io/v1
+          credentialsSecret:
+            name: alibabacloud-credentials
+          imageId: ${WORKER_MACHINESET_IMAGE}
+          instanceType: ${OPENSHIFT_WORKLOAD_NODE_INSTANCE_TYPE}
+          kind: AlibabaCloudMachineProviderConfig
+          ramRoleName: ${CLUSTER_NAME}-role-worker
+          regionId: ${CLUSTER_REGION}
+          resourceGroup:
+            name: ${CLUSTER_NAME}-rg
+            type: Name
+          securityGroups:
+          - tags:
+            - Key: kubernetes.io/cluster/${CLUSTER_NAME}
+              Value: owned
+            - Key: GISV
+              Value: ocp
+            - Key: sigs.k8s.io/cloud-provider-alibaba/origin
+              Value: ocp
+            - Key: Name
+              Value: ${CLUSTER_NAME}-sg-worker
+            type: Tags
+          systemDisk:
+            category: cloud_essd
+            size: ${OPENSHIFT_WORKLOAD_NODE_VOLUME_SIZE}
+          tag:
+          - Key: kubernetes.io/cluster/${CLUSTER_NAME}
+            Value: owned
+          - Key: GISV
+            Value: ocp
+          - Key: sigs.k8s.io/cloud-provider-alibaba/origin
+            Value: ocp
+          userDataSecret:
+            name: worker-user-data
+          vSwitch:
+            tags:
+            - Key: kubernetes.io/cluster/${CLUSTER_NAME}
+              Value: owned
+            - Key: GISV
+              Value: ocp
+            - Key: sigs.k8s.io/cloud-provider-alibaba/origin
+              Value: ocp
+            - Key: Name
+              Value: ${CLUSTER_NAME}-vswitch-${CLUSTER_REGION}a
+            type: Tags
+          vpcId: ""
+          zoneId: ${CLUSTER_REGION}a
+        taints:
+        - key: node-role.kubernetes.io/workload
+          effect: NoSchedule

--- a/workload-node-machineset-ibmcloud.yaml
+++ b/workload-node-machineset-ibmcloud.yaml
@@ -1,0 +1,49 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+    machine.openshift.io/cluster-api-machine-role: workload
+    machine.openshift.io/cluster-api-machine-type: workload
+  name: ${CLUSTER_NAME}-workload-${CLUSTER_REGION}
+  namespace: openshift-machine-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+      machine.openshift.io/cluster-api-machineset: ${CLUSTER_NAME}-workload-${CLUSTER_REGION}
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+        machine.openshift.io/cluster-api-machine-role: workload
+        machine.openshift.io/cluster-api-machine-type: workload
+        machine.openshift.io/cluster-api-machineset: ${CLUSTER_NAME}-workload-${CLUSTER_REGION}
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/workload: ""
+      providerSpec:
+        value:
+          apiVersion: ibmcloudproviderconfig.openshift.io/v1beta1
+          credentialsSecret:
+            name: ibmcloud-credentials
+          image: ${CLUSTER_NAME}-rhcos
+          kind: IBMCloudMachineProviderSpec
+          primaryNetworkInterface:
+              securityGroups:
+              - ${CLUSTER_NAME}-sg-cluster-wide
+              - ${CLUSTER_NAME}-sg-openshift-net
+              # Installer: Can/should the user actually specify this, or will one get created during install and pulled in here?
+              subnet: ${CLUSTER_NAME}-subnet-compute-${CLUSTER_REGION}-1
+          profile: ${OPENSHIFT_WORKLOAD_NODE_INSTANCE_TYPE}
+          region: ${CLUSTER_REGION}
+          resourceGroup: ${CLUSTER_NAME}
+          userDataSecret:
+              name: worker-user-data
+          vpc: ${CLUSTER_NAME}-vpc
+          zone: ${CLUSTER_REGION}-1
+        taints:
+        - key: node-role.kubernetes.io/workload
+          effect: NoSchedule


### PR DESCRIPTION
Adding infra and workload nodes for alibaba cloud.

this will create 2 infra machine sets (1 in zone a and 2 in zone b, because there is no c zone)

Doc I used on how to create machinesets for alibaba: https://deploy-preview-41943--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-alibaba.html

Passing run: jenkins.../scale-ci/job/paige-e2e-multibranch/job/cluster-post-config/57/console

Fixes: https://github.com/openshift-qe/ocp-qe-perfscale-ci/issues/63
