### PR TITLE
Scale jobs in loaded-upgrade

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,14 +1,20 @@
 
 def aws = null
 def install = null
+def scale_up = null
 def loaded_ci = null
+def health_check = null
 def upgrade_ci = null
 def destroy_ci = null
+def must_gather = null
 def build_string = "DEFAULT"
 def load_result = "SUCCESS"
 def loaded_url = ""
 def upgrade_url = ""
+def must_gather_url = ""
 def proxy_settings = ""
+def status = "PASS"
+
 
 def userId = currentBuild.rawBuild.getCause(hudson.model.Cause$UserIdCause)?.userId
 if (userId) {
@@ -41,16 +47,52 @@ pipeline{
         string(name: 'MASTER_COUNT', defaultValue: '3', description: 'Number of master nodes in your cluster to create.')
         string(name: "WORKER_COUNT", defaultValue: '3', description: 'Number of worker nodes in your cluster to create.')
 
+        separator(name: "SCALE_UP_JOB_INFO", sectionHeader: "Scale Up Job Options", sectionHeaderStyle: """
+				font-size: 18px;
+				font-weight: bold;
+				font-family: 'Orienta', sans-serif;
+			""")
+
+        string(name: 'SCALE_UP', defaultValue: '0', description: 'If value is set to anything greater than 0, cluster will be scaled up before executing the workload.')
+        string(name: 'SCALE_DOWN', defaultValue: '0', description:
+        '''If value is set to anything greater than 0, cluster will be scaled down after the execution of the workload is complete,<br>
+        if the build fails, scale down may not happen, user should review and decide if cluster is ready for scale down or re-run the job on same cluster.'''
+        )
         separator(name: "SCALE_CI_JOB_INFO", sectionHeader: "Scale-CI Job Options", sectionHeaderStyle: """
 				font-size: 18px;
 				font-weight: bold;
 				font-family: 'Orienta', sans-serif;
 			""")
-        choice(choices: ["","cluster-density","pod-density","node-density","etcd-perf","max-namespaces","max-services","pod-network-policy-test","router-perf","storage-perf"], name: 'CI_TYPE', description: '''Type of scale-ci job to run. Can be left blank to not run ci job''')
-        string(name: 'JOB_ITERATIONS', defaultValue: '1000', description: 'This variable configures the number of cluster-density jobs iterations to perform (1 namespace per iteration). By default 1000.')
-        string(name: 'NODE_COUNT', defaultValue: '3', description: 'Number of nodes to be used in your cluster for this workload.')
-        string(name: "PODS_PER_NODE", defaultValue: '150', description: 'Number of pods per node.')
+        choice(choices: ["","cluster-density","pod-density","node-density","node-density-heavy","etcd-perf","max-namespaces","max-services","pod-network-policy-test","router-perf","network-perf-hostnetwork-network-test","network-perf-pod-network-test","network-perf-serviceip-network-test"], name: 'CI_TYPE', description: '''Type of scale-ci job to run. Can be left blank to not run ci job <br>
+        Router-perf tests will use all defaults if selected, all parameters in this section below will be ignored ''')
 
+
+        string(name: 'VARIABLE', defaultValue: '1000', description: '''
+        This variable configures parameter needed for each type of workload. By default 1000. <br>
+        pod-density: This will export PODS env variable; set to 200 * num_workers, work up to 250 * num_workers. Creates as many "sleep" pods as configured in this environment variable. <br>
+        cluster-density: This will export JOB_ITERATIONS env variable; set to 4 * num_workers. This variable sets the number of iterations to perform (1 namespace per iteration). <br>
+        max-namespaces: This will export NAMESPACE_COUNT env variable; set to ~30 * num_workers. The number of namespaces created by Kube-burner. <br>
+        max-services: This will export SERVICE_COUNT env variable; set to 200 * num_workers, work up to 250 * num_workers. Creates n-replicas of an application deployment (hello-openshift) and a service in a single namespace. <br>
+        node-density: This will export PODS_PER_NODE env variable; set to 200, work up to 250. Creates as many "sleep" pods as configured in this variable - existing number of pods on node. <br>
+        node-density-heavy: This will export PODS_PER_NODE env variable; set to 200, work up to 250. Creates this number of applications proportional to the calculated number of pods / 2 <br>
+        Read here for detail of each variable: <br>
+        https://github.com/cloud-bulldozer/e2e-benchmarking/blob/master/workloads/kube-burner/README.md <br>
+        ''')
+
+        separator(name: "NODE_DENSITY_JOB_INFO", sectionHeader: "Node Density Job Options", sectionHeaderStyle: """
+				font-size: 14px;
+				font-weight: bold;
+				font-family: 'Orienta', sans-serif;
+			""")
+        string(name: 'NODE_COUNT', defaultValue: '3', description: 'Number of worker nodes to be used in your cluster for this workload.')
+
+        separator(name: "NETWORK_PERF_INFO", sectionHeader: "Node Density Job Options", sectionHeaderStyle: """
+				font-size: 14px;
+				font-weight: bold;
+				font-family: 'Orienta', sans-serif;
+			""")
+        choice(choices: ['smoke', 'pod2pod', 'hostnet', 'pod2svc'], name: 'WORKLOAD_TYPE', description: 'Workload type')
+        booleanParam(name: "NETWORK_POLICY", defaultValue: false, description: "If enabled, benchmark-operator will create a network policy to allow ingress trafic in uperf server pods")
 
         separator(name: "UPGRADE_INFO", sectionHeader: "Upgrade Options", sectionHeaderStyle: """
 				font-size: 18px;
@@ -58,21 +100,21 @@ pipeline{
 				font-family: 'Orienta', sans-serif;
 			""")
         string(name: 'UPGRADE_VERSION', description: 'This variable sets the version number you want to upgrade your OpenShift cluster to (can list multiple by separating with comma, no spaces).')
+        booleanParam(name: 'EUS_UPGRADE', defaultValue: false, description: '''This variable will perform an EUS type upgrade <br>
+        See "https://docs.google.com/document/d/1396VAUFLmhj8ePt9NfJl0mfHD7pUT7ii30AO7jhDp0g/edit#heading=h.bv3v69eaalsw" for how to run
+        ''')
+        choice(choices: ['fast', 'eus', 'candidate', 'stable'], name: 'EUS_CHANNEL', description: 'EUS Channel type, will be ignored if EUS_UPGRADE is not set to true')
+
         booleanParam(name: 'ENABLE_FORCE', defaultValue: true, description: 'This variable will force the upgrade or not')
         booleanParam(name: 'SCALE', defaultValue: false, description: 'This variable will scale the cluster up one node at the end up the upgrade')
         string(name: 'MAX_UNAVAILABLE', defaultValue: "1", description: 'This variable will set the max number of unavailable nodes during the upgrade')
-
 
         separator(name: "GENERAL_BUILD_INFO", sectionHeader: "General Options", sectionHeaderStyle: """
 				font-size: 18px;
 				font-weight: bold;
 				font-family: 'Orienta', sans-serif;
 			""")
-        string(name: 'SCALE_UP', defaultValue: '0', description: 'If value is set to anything greater than 0, cluster will be scaled up before executing the workload.')
-        string(name: 'SCALE_DOWN', defaultValue: '0', description:
-        '''If value is set to anything greater than 0, cluster will be scaled down after the execution of the workload is complete,<br>
-        if the build fails, scale down may not happen, user should review and decide if cluster is ready for scale down or re-run the job on same cluster.'''
-        )
+
         booleanParam(name: 'WRITE_TO_FILE', defaultValue: true, description: 'Value to write to google sheet (will run https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/scale-ci/job/paige-e2e-multibranch/job/write-to_sheet)')
         booleanParam(name: 'DESTROY_WHEN_DONE', defaultValue: 'False', description: 'If you want to destroy the cluster created at the end of your run ')
         string(name:'JENKINS_AGENT_LABEL',defaultValue:'oc45',description:
@@ -185,6 +227,12 @@ REG_CI_BUILDS=registry.svc.ci.openshift.org
 GIT_FLEXY_SSH_KEY=e2f7029f-ab8d-4987-8950-39feb80d5fbd
 GIT_PRIVATE_SSH_KEY=1d2207b6-15c0-4cb0-913a-637788d12257
 REG_SVC_CI=9a9187c6-a54c-452a-866f-bea36caea6f9''' ) ]
+
+                        if( install.result.toString()  != "SUCCESS") {
+                           sh 'echo "build failed"'
+                           currentBuild.result = "FAILURE"
+                           status = "Install failed"
+                        }
                     } else {
                      copyArtifacts(
                         filter: '',
@@ -201,60 +249,72 @@ REG_SVC_CI=9a9187c6-a54c-452a-866f-bea36caea6f9''' ) ]
                             build_string = install.number.toString()
                     }
                  if ( build_string != "DEFAULT") {
-                 copyArtifacts(
-                    fingerprintArtifacts: true,
-                    projectName: 'ocp-common/Flexy-install',
-                    selector: specific(build_string),
-                    filter: "workdir/install-dir/",
-                    target: 'flexy-artifacts'
-                   )
-                if (fileExists("flexy-artifacts/workdir/install-dir/client_proxy_setting.sh")) {
-                 sh "echo yes"
-                 proxy_settings = sh returnStdout: true, script: 'cat flexy-artifacts/workdir/install-dir/client_proxy_setting.sh'
-                 proxy_settings = proxy_settings.replace('export ', '')
-                }
+                     copyArtifacts(
+                        fingerprintArtifacts: true,
+                        projectName: 'ocp-common/Flexy-install',
+                        selector: specific(build_string),
+                        filter: "workdir/install-dir/",
+                        target: 'flexy-artifacts'
+                       )
+                    if (fileExists("flexy-artifacts/workdir/install-dir/client_proxy_setting.sh")) {
+                     sh "echo yes"
+                     proxy_settings = sh returnStdout: true, script: 'cat flexy-artifacts/workdir/install-dir/client_proxy_setting.sh'
+                     proxy_settings = proxy_settings.replace('export ', '')
+                    }
 
-                ENV_VARS += '\n' + proxy_settings
-                sh "echo $ENV_VARS"
-                }
+                    ENV_VARS += '\n' + proxy_settings
+                    sh "echo $ENV_VARS"
                  }
+               }
             }
+        }
+        stage("Scale Up Cluster") {
+           agent { label params['JENKINS_AGENT_LABEL'] }
+           steps {
+            script{
+             if( build_string != "DEFAULT" && status == "PASS") {
+              if(params.SCALE_UP.toInteger() > 0) {
+                scale_up = build job: 'scale-ci/e2e-benchmarking-multibranch-pipeline/cluster-workers-scaling/', parameters: [string(name: 'BUILD_NUMBER', value: BUILD_NUMBER), text(name: "ENV_VARS", value: ENV_VARS), string(name: 'WORKER_COUNT', value: SCALE_UP), string(name: 'JENKINS_AGENT_LABEL', value: JENKINS_AGENT_LABEL)]
+
+                if( scale_up != null && scale_up.result.toString() != "SUCCESS") {
+                   status = "Scale Up Failed"
+                   currentBuild.result = "FAILURE"
+                }
+               }
+              } else {
+                sh 'echo "Installation of cluster failed, not running scale-up job"'
+              }
+            }
+           }
         }
         stage("Perf Testing"){
             agent { label params['JENKINS_AGENT_LABEL'] }
             steps{
-                    script {
+                script {
+                    if( build_string != "DEFAULT" && status == "PASS") {
+                   if( ["cluster-density","pod-density","node-density","node-density-heavy", "max-namespaces","max-services","pod-density-heavy"].contains(params.CI_TYPE) ) {
+                        loaded_ci = build job: "scale-ci/e2e-benchmarking-multibranch-pipeline/kube-burner", propagate: false, parameters:[string(name: "BUILD_NUMBER", value: "${build_string}"),string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL),string(name: "WORKLOAD", value: CI_TYPE),string(name: "VARIABLE", value: VARIABLE),string(name: 'NODE_COUNT', value: NODE_COUNT),text(name: "ENV_VARS", value: ENV_VARS),booleanParam(name: "WRITE_TO_FILE", value: WRITE_TO_FILE),string(name: "E2E_BENCHMARKING_REPO", value: E2E_BENCHMARKING_REPO),string(name: "E2E_BENCHMARKING_REPO_BRANCH", value: E2E_BENCHMARKING_REPO_BRANCH)]
+                       } else if (params.CI_TYPE == "etcd-perf") {
+                       loaded_ci = build job: "scale-ci/e2e-benchmarking-multibranch-pipeline/etcd-perf", propagate: false, parameters:[string(name: "BUILD_NUMBER", value: "${build_string}"),string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL),text(name: "ENV_VARS", value: ENV_VARS),string(name: "E2E_BENCHMARKING_REPO", value: E2E_BENCHMARKING_REPO),string(name: "E2E_BENCHMARKING_REPO_BRANCH", value: E2E_BENCHMARKING_REPO_BRANCH),booleanParam(name: "WRITE_TO_FILE", value: WRITE_TO_FILE)]
+                       } else if (params.CI_TYPE == "router-perf") {
+                       loaded_ci = build job: "scale-ci/e2e-benchmarking-multibranch-pipeline/router-perf",propagate: false, parameters:[string(name: "BUILD_NUMBER", value: "${build_string}"),string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL),text(name: "ENV_VARS", value: ENV_VARS),string(name: "E2E_BENCHMARKING_REPO", value: E2E_BENCHMARKING_REPO),string(name: "E2E_BENCHMARKING_REPO_BRANCH", value: E2E_BENCHMARKING_REPO_BRANCH),booleanParam(name: "WRITE_TO_FILE", value: WRITE_TO_FILE)]
+                       }else if ( ["network-perf-pod-network-test","network-perf-serviceip-network-test","network-perf-hostnetwork-network-test"].contains(params.CI_TYPE) ) {
+                       loaded_ci = build job: "scale-ci/paige-e2e-multibranch/network-perf", propagate: false, parameters:[string(name: "BUILD_NUMBER", value: "${build_string}"),string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL),string(name: "WORKLOAD_TYPE", value: WORKLOAD_TYPE),booleanParam(name: "NETWORK_POLICY", value: NETWORK_POLICY),text(name: "ENV_VARS", value: ENV_VARS),string(name: "E2E_BENCHMARKING_REPO", value: E2E_BENCHMARKING_REPO),string(name: "E2E_BENCHMARKING_REPO_BRANCH", value: E2E_BENCHMARKING_REPO_BRANCH),booleanParam(name: "WRITE_TO_FILE", value: WRITE_TO_FILE)]
+                        }else{
+                        sh 'echo "No Scale-ci Job"'
+                       }
 
-                        if( build_string != "DEFAULT" ) {
-                          if(params.CI_TYPE == "cluster-density") {
-                            loaded_ci = build job: "scale-ci/e2e-benchmarking-multibranch-pipeline/cluster-density", propagate: false, parameters:[string(name: "BUILD_NUMBER", value: "${build_string}"),string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL),string(name: "JOB_ITERATIONS", value: JOB_ITERATIONS),text(name: "ENV_VARS", value: ENV_VARS),string(name: "SCALE_UP", value: SCALE_UP),string(name: "SCALE_DOWN", value: SCALE_DOWN),booleanParam(name: "WRITE_TO_FILE", value: WRITE_TO_FILE),string(name: "E2E_BENCHMARKING_REPO", value: E2E_BENCHMARKING_REPO),string(name: "E2E_BENCHMARKING_REPO_BRANCH", value: E2E_BENCHMARKING_REPO_BRANCH)]
-                           } else if (params.CI_TYPE == "pod-density" ) {
-                            loaded_ci = build job: "scale-ci/e2e-benchmarking-multibranch-pipeline/pod-density", propagate: false, parameters:[string(name: "BUILD_NUMBER", value: "${build_string}"),string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL),string(name: "PODS", value: JOB_ITERATIONS),text(name: "ENV_VARS", value: ENV_VARS),string(name: "SCALE_UP", value: SCALE_UP),string(name: "SCALE_DOWN", value: SCALE_DOWN),booleanParam(name: "WRITE_TO_FILE", value: WRITE_TO_FILE),string(name: "E2E_BENCHMARKING_REPO", value: E2E_BENCHMARKING_REPO),string(name: "E2E_BENCHMARKING_REPO_BRANCH", value: E2E_BENCHMARKING_REPO_BRANCH) ]
-                           } else if (params.CI_TYPE == "node-density") {
-                            loaded_ci = build job: "scale-ci/e2e-benchmarking-multibranch-pipeline/node-density", propagate: false, parameters:[string(name: "BUILD_NUMBER", value: "${build_string}"),string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL),string(name: "PODS_PER_NODE", value: PODS_PER_NODE),string(name: 'NODE_COUNT', value: NODE_COUNT),text(name: "ENV_VARS", value: ENV_VARS),string(name: "SCALE_UP", value: SCALE_UP),string(name: "SCALE_DOWN", value: SCALE_DOWN),booleanParam(name: "WRITE_TO_FILE", value: WRITE_TO_FILE),string(name: "E2E_BENCHMARKING_REPO", value: E2E_BENCHMARKING_REPO),string(name: "E2E_BENCHMARKING_REPO_BRANCH", value: E2E_BENCHMARKING_REPO_BRANCH) ]
-                           } else if (params.CI_TYPE == "etcd-perf") {
-                           loaded_ci = build job: "scale-ci/e2e-benchmarking-multibranch-pipeline/etcd-perf", propagate: false, parameters:[string(name: "BUILD_NUMBER", value: "${build_string}"),string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL),string(name: "SCALE_UP", value: SCALE_UP),string(name: "SCALE_DOWN", value: SCALE_DOWN),text(name: "ENV_VARS", value: ENV_VARS),string(name: "E2E_BENCHMARKING_REPO", value: E2E_BENCHMARKING_REPO),string(name: "E2E_BENCHMARKING_REPO_BRANCH", value: E2E_BENCHMARKING_REPO_BRANCH)]
-                           } else if (params.CI_TYPE == "max-namespaces") {
-                           loaded_ci = build job: "scale-ci/e2e-benchmarking-multibranch-pipeline/max-namespaces", propagate: false,parameters:[string(name: "BUILD_NUMBER", value: "${build_string}"),string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL),string(name: "NAMESPACE_COUNT", value: JOB_ITERATIONS),text(name: "ENV_VARS", value: ENV_VARS),string(name: "SCALE_UP", value: SCALE_UP),string(name: "SCALE_DOWN", value: SCALE_DOWN),booleanParam(name: "WRITE_TO_FILE", value: WRITE_TO_FILE),string(name: "E2E_BENCHMARKING_REPO", value: E2E_BENCHMARKING_REPO),string(name: "E2E_BENCHMARKING_REPO_BRANCH", value: E2E_BENCHMARKING_REPO_BRANCH) ]
-                           } else if (params.CI_TYPE == "max-services") {
-                           loaded_ci = build job: "scale-ci/e2e-benchmarking-multibranch-pipeline/max-services",propagate: false, parameters:[string(name: "BUILD_NUMBER", value: "${build_string}"),string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL),string(name: "SERVICE_COUNT", value: JOB_ITERATIONS),text(name: "ENV_VARS", value: ENV_VARS),string(name: "SCALE_UP", value: SCALE_UP),string(name: "SCALE_DOWN", value: SCALE_DOWN),booleanParam(name: "WRITE_TO_FILE", value: WRITE_TO_FILE),string(name: "E2E_BENCHMARKING_REPO", value: E2E_BENCHMARKING_REPO),string(name: "E2E_BENCHMARKING_REPO_BRANCH", value: E2E_BENCHMARKING_REPO_BRANCH) ]
-                           } else if (params.CI_TYPE == "pod-network-policy-test") {
-                           loaded_ci = build job: "scale-ci/e2e-benchmarking-multibranch-pipeline/pod-network-policy-test", propagate: false, parameters:[string(name: "BUILD_NUMBER", value: "${build_string}"), string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL),string(name: "SCALE_UP", value: SCALE_UP),string(name: "SCALE_DOWN", value: SCALE_DOWN),text(name: "ENV_VARS", value: ENV_VARS),string(name: "E2E_BENCHMARKING_REPO", value: E2E_BENCHMARKING_REPO),string(name: "E2E_BENCHMARKING_REPO_BRANCH", value: E2E_BENCHMARKING_REPO_BRANCH)]
-                           } else if (params.CI_TYPE == "router-perf") {
-                           loaded_ci = build job: "scale-ci/e2e-benchmarking-multibranch-pipeline/router-perf",propagate: false, parameters:[string(name: "BUILD_NUMBER", value: "${build_string}"),string(name: "SCALE_UP", value: SCALE_UP),string(name: "SCALE_DOWN", value: SCALE_DOWN),string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL),text(name: "ENV_VARS", value: ENV_VARS),string(name: "E2E_BENCHMARKING_REPO", value: E2E_BENCHMARKING_REPO),string(name: "E2E_BENCHMARKING_REPO_BRANCH", value: E2E_BENCHMARKING_REPO_BRANCH)]
-                           }else if (params.CI_TYPE == "storage-perf") {
-                           loaded_ci = build job: "scale-ci/e2e-benchmarking-multibranch-pipeline/storage-perf", propagate: false, parameters:[string(name: "BUILD_NUMBER", value: "${build_string}"),string(name: "SCALE_UP", value: SCALE_UP),string(name: "SCALE_DOWN", value: SCALE_DOWN),string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL),text(name: "ENV_VARS", value: ENV_VARS),string(name: "E2E_BENCHMARKING_REPO", value: E2E_BENCHMARKING_REPO),string(name: "E2E_BENCHMARKING_REPO_BRANCH", value: E2E_BENCHMARKING_REPO_BRANCH)]
-                           } else{
-                            sh 'echo "No Scale-ci Job"'
-                           }
-
-                          if( loaded_ci != null ) {
-                            load_result = loaded_ci.result.toString()
-                          }
-                          }else{
-                            sh 'echo "Installation of cluster failed, not running scale-ci job"'
-                           }
+                        if( loaded_ci != null ) {
+                          load_result = loaded_ci.result.toString()
+                          if( scale_up.result.toString() != "SUCCESS") {
+                               status = "Scale Up Failed"
+                               currentBuild.result = "FAILURE"
+                            }
                         }
+                      } else{
+                        sh 'echo "Earlier job failed"'
+                       }
+                    }
             }
         }
         stage('Upgrade'){
@@ -262,55 +322,48 @@ REG_SVC_CI=9a9187c6-a54c-452a-866f-bea36caea6f9''' ) ]
             steps{
                 script{
                     if( build_string != "DEFAULT" ) {
-                        if( load_result == "SUCCESS" ) {
+                        if( status == "PASS" ) {
                             if( UPGRADE_VERSION != "" ) {
-                                upgrade_ci = build job: "scale-ci/e2e-benchmarking-multibranch-pipeline/upgrade", propagate: false,parameters:[string(name: "BUILD_NUMBER", value: build_string),string(name: "MAX_UNAVAILABLE", value: MAX_UNAVAILABLE),string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL),string(name: "UPGRADE_VERSION", value: UPGRADE_VERSION),booleanParam(name: "WRITE_TO_FILE", value: WRITE_TO_FILE),booleanParam(name: "ENABLE_FORCE", value: ENABLE_FORCE),booleanParam(name: "SCALE", value: SCALE),text(name: "ENV_VARS", value: ENV_VARS)]
+                                upgrade_ci = build job: "scale-ci/e2e-benchmarking-multibranch-pipeline/upgrade", propagate: false,parameters:[string(name: "BUILD_NUMBER", value: build_string),string(name: "MAX_UNAVAILABLE", value: MAX_UNAVAILABLE),string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL),string(name: "UPGRADE_VERSION", value: UPGRADE_VERSION),booleanParam(name: "EUS_UPGRADE", value: EUS_UPGRADE),string(name: "EUS_CHANNEL", value: EUS_CHANNEL),booleanParam(name: "WRITE_TO_FILE", value: WRITE_TO_FILE),booleanParam(name: "ENABLE_FORCE", value: ENABLE_FORCE),booleanParam(name: "SCALE", value: SCALE),text(name: "ENV_VARS", value: ENV_VARS)]
+                                if( upgrade_ci.result.toString() != "SUCCESS") {
+                                   status = "Upgrade Failed"
+                                   currentBuild.result = "FAILURE"
+                                }
                             } else {
-                            sh 'echo "No upgrade version set, not running upgrade"'
+                                sh 'echo "No upgrade version set, not running upgrade"'
                             }
                         } else{
-                            sh 'echo "Scale ci job failed, not running upgrade"'
+                            sh 'echo "One of the previous jobs failed, not running upgrade"'
                            }
-
                     } else {
                         sh 'echo "Installation of cluster failed, not running upgrade"'
                     }
                 }
             }
         }
+
         stage("Write out results") {
             agent { label params['JENKINS_AGENT_LABEL'] }
-                steps{
-                    script{
-                      def status = "PASS"
-                      if(params.WRITE_TO_FILE == true) {
-                         sh "echo write to file $loaded_ci "
-                          if ( install != null ) {
-                            if( install.result.toString() != "SUCCESS" ) {
-                                status = "Install Failed"
-                            }
-                          }
-                         if( load_result == "SUCCESS" ) {
-                            if ( upgrade_ci != null) {
-                             if( upgrade_ci.result.toString()  != "SUCCESS") {
-                               status = "Upgrade Failed"
-                              }
-                            }
-                         } else {
-                            status = "Load Failed"
-                         }
-                        if(loaded_ci != null ) {
-                            loaded_url = loaded_ci.absoluteUrl
-                        }
-                        if(upgrade_ci != null ) {
-                            upgrade_url = upgrade_ci.absoluteUrl
-                        }
-                        build job: 'scale-ci/e2e-benchmarking-multibranch-pipeline/write-scale-ci-results', propagate: false,parameters: [string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL), string(name: "BUILD_NUMBER", value: build_string), string(name: 'CI_STATUS', value: "${status}"), string(name: 'UPGRADE_JOB_URL', value: upgrade_url),
-                            text(name: "ENV_VARS", value: ENV_VARS), string(name: 'CI_JOB_URL', value: loaded_url), booleanParam(name: 'ENABLE_FORCE', value: ENABLE_FORCE), booleanParam(name: 'SCALE', value: SCALE), string(name: 'LOADED_JOB_URL', value: BUILD_URL), string(name: 'JOB', value: "loaded-upgrade")]
-                         }
+            steps{
+                script{
+                  if(params.WRITE_TO_FILE == true) {
+                     sh "echo write to file $loaded_ci "
 
+                    if(loaded_ci != null ) {
+                        loaded_url = loaded_ci.absoluteUrl
                     }
-                  }
+                    if(upgrade_ci != null ) {
+                        upgrade_url = upgrade_ci.absoluteUrl
+                    }
+                    if ( must_gather != null ) {
+                        must_gather_url = must_gather.absoluteUrl
+                    }
+                    build job: 'scale-ci/paige-e2e-multibranch/write-scale-ci-results', propagate: false,parameters: [string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL), string(name: "BUILD_NUMBER", value: build_string), string(name: 'CI_STATUS', value: "${status}"), string(name: 'UPGRADE_JOB_URL', value: upgrade_url),
+                        text(name: "ENV_VARS", value: ENV_VARS), string(name: 'CI_JOB_URL', value: loaded_url), booleanParam(name: 'ENABLE_FORCE', value: ENABLE_FORCE), booleanParam(name: 'SCALE', value: SCALE), string(name: 'LOADED_JOB_URL', value: BUILD_URL), string(name: 'JOB', value: "loaded-upgrade"), , string(name: 'MUST_GATHER_URL', value: must_gather_url)]
+                    }
+
+                }
+              }
         }
         stage('Destroy Flexy Cluster'){
             agent { label params['JENKINS_AGENT_LABEL'] }
@@ -321,41 +374,16 @@ REG_SVC_CI=9a9187c6-a54c-452a-866f-bea36caea6f9''' ) ]
                     } else if(install == null && params.DESTROY_WHEN_DONE == true) {
                         destroy_ci = build job: 'ocp-common/Flexy-destroy', parameters: [string(name: "BUILD_NUMBER", value: build_string),string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL)]
                     }
+
+                    if( destroy_ci != null) {
+                        sh 'echo "destroy not null"'
+                        if( destroy_ci.result.toString() != "SUCCESS") {
+                            sh 'echo "destroy failed"'
+                            currentBuild.result = "FAILURE"
+                        }
+                    }
                 }
             }
         }
-        stage('Setting Proper Status'){
-            agent { label params['JENKINS_AGENT_LABEL'] }
-            steps{
-                script{
-                if( build_string == "DEFAULT" ) {
-                 sh 'echo "build failed"'
-                 currentBuild.result = "FAILURE"
-
-                }
-                if( load_result != "SUCCESS" ) {
-                    sh 'echo "load failed"'
-                    currentBuild.result = "FAILURE"
-                }
-                if( upgrade_ci != null ) {
-                    sh 'echo "upgrade not null"'
-                    if( upgrade_ci.result.toString() != "SUCCESS" ) {
-
-                         sh 'echo "upgrade failed"'
-                         currentBuild.result = "FAILURE"
-                    }
-                }
-                if( destroy_ci != null) {
-                    sh 'echo "destroy not null"'
-                    if( destroy_ci.result.toString() != "SUCCESS") {
-                        sh 'echo "destroy failed"'
-                        currentBuild.result = "FAILURE"
-                    }
-                }
-             }
-         }
-         }
-
-       }
-
+    }
 }

--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 ## Steps
 1. Create cluster or using existing flexy job
-2. Load cluster using scale-ci
-3. Upgrade Cluster 
-4. Destroy (based on parameter)
+2. Scale up cluster (if wanted)
+3. Load cluster using scale-ci
+4. Cluster Check Using Cerberus
+5. Upgrade Cluster 
+6. Perform must-gather if any failures during run
+7. Destroy (based on parameter)
 
 ## Purpose
 Run Loaded Upgrade workload on a given OpenShift cluster or it can create one for you based on ocp version, network type, installation type and cloud type. 
@@ -16,22 +19,32 @@ Types:
 * "cluster-density"
 * "pod-density"
 * "node-density"
+* "node-density-heavy"
 * "etcd-perf"
 * "max-namespaces"
 * "max-services"
 * "pod-network-policy-test"
 * "router-perf"
 * "storage-perf"
+* "network-perf-hostnetwork-network-test"
+* "network-perf-pod-network-test"
+* "network-perf-serviceip-network-test"
 
-* NOTE: the cluster-density, pod-density and node-density point to my fork and will write results to [sheet](https://docs.google.com/spreadsheets/d/1uiKGYQyZ7jxchZRU77lsINpa23HhrFWjphsqGjTD-u4/edit?usp=sharing)
-All other loading jobs point to the main [scale-ci](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/) repo 
+
+* NOTE: The scale-ci tests have a boolean parameter (write_to_sheet) that will write results to this [sheet](https://docs.google.com/spreadsheets/d/1uiKGYQyZ7jxchZRU77lsINpa23HhrFWjphsqGjTD-u4/edit?usp=sharing) 
 
 ## Upgrade
 
-For the upgrade you can pass multiple versions (delimited by a comma) to the script and it'll execute each one sequentially 
+For the upgrade you can pass multiple versions (delimited by a comma) to the script and it'll execute each upgrade sequentially
+
+
 It'll use quay.io/openshift-release-dev/ocp-release (all builds) or registry.ci.openshift.org/ocp/release (nightly builds only)
 
+Or if selected, you can execute and EUS style of upgrade. For more information on this type of upgrade see [documentation](https://docs.openshift.com/container-platform/4.9/updating/preparing-eus-eus-upgrade.html)
+You can also set the the type of upgrade channel that is set in the EUS upgrade. IE fast, stable, eus, or candidate 
+
 If the upgrade fails it'll run a quick diagnostics (similar to UpgradeCI) and run must-gather to get results
+
 
 
 ## Write to File
@@ -40,7 +53,6 @@ If writeToFile is set to True it will print off results to this [sheet](https://
 This will print off results for the scale-ci job (to the specific tab based on the job), the upgrade, and the overall results of the loaded upgrade 
 
 Based on the ending cluster version, results for the overall loaded-upgrade job will also be printed into this [sheet](https://docs.google.com/spreadsheets/d/1yqQxAxLcYEF-VHlQ_KDLs8NOFsRLb4R8V2UM9VFaRBI/edit?ouid=100476695391511856299&usp=sheets_home&ths=true) on the clusterversion tab  
-
 
 
 ### Author


### PR DESCRIPTION
This is adding in calls to scale up and the 2 more new general scale-ci jobs (kube-burner and network-perf). Those 2 pr's need to go in before this one and I'll update the build links 

For etcd-perf and router-perf I took out the passing of scale-up and scale-down so it doesn't scale twice 

I wasn't sure where scale-down fits into this workload. Any ideas? 


NOTE: Wanting to get this initial PR in before adding in a cerberus check as well as getting a must-gather if any failures