### PR TITLE
Kube burner

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,6 +54,8 @@ pipeline {
                SOMEVARn='envn-test'<br>
                </p>'''
             )
+        
+        booleanParam(name: 'INFRA_WORKLOAD_INSTALL', defaultValue: false, description: 'Install workload and infrastructure nodes even if less than 50 nodes. <br> Checking this parameter box is valid only when SCALE_UP is greater than 0.')
         string(name: 'SCALE_UP', defaultValue: '0', description: 'If value is set to anything greater than 0, cluster will be scaled up before executing the workload.')
         string(name: 'SCALE_DOWN', defaultValue: '0', description:
         '''If value is set to anything greater than 0, cluster will be scaled down after the execution of the workload is complete,<br>
@@ -69,7 +71,8 @@ pipeline {
       steps{
         script{
           if(params.SCALE_UP.toInteger() > 0) {
-            build job: 'scale-ci/e2e-benchmarking-multibranch-pipeline/cluster-workers-scaling/', parameters: [string(name: 'BUILD_NUMBER', value: BUILD_NUMBER), text(name: "ENV_VARS", value: ENV_VARS), string(name: 'WORKER_COUNT', value: SCALE_UP), string(name: 'JENKINS_AGENT_LABEL', value: JENKINS_AGENT_LABEL)]
+            
+	build job: 'scale-ci/e2e-benchmarking-multibranch-pipeline/cluster-workers-scaling/', parameters: [string(name: 'BUILD_NUMBER', value: BUILD_NUMBER), text(name: "ENV_VARS", value: ENV_VARS), string(name: 'WORKER_COUNT', value: SCALE_UP), string(name: 'JENKINS_AGENT_LABEL', value: JENKINS_AGENT_LABEL), booleanParam(name: 'INFRA_WORKLOAD_INSTALL', value: INFRA_WORKLOAD_INSTALL) ]
           }
         }
         deleteDir()


### PR DESCRIPTION
[OCPQE-9178]
(https://issues.redhat.com/browse/OCPQE-9178)

Install Infra and workload nodes on cluster with worker nodes <=50

added the same parameter as of 'pr' https://github.com/openshift-qe/ocp-qe-perfscale-ci/pull/101 to kube-burner branch.

positive test case passed:[expected job done]   INFRA_WORKLOAD_INSTALL is checked
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/sninganu-e2e-benchmarking-multibranch-pipeline/job/kube-burner/16/console


negative test case passed  INFRA_WORKLOAD_INSTALL is unchecked
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/sninganu-e2e-benchmarking-multibranch-pipeline/job/kube-burner/17/console