### PR TITLE
Adding working print of certain scale results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+*/*.pyc
+*/**.pyc
+*/__pycache__
+*/__pycache__/*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,8 @@ pipeline {
         booleanParam(name: 'SCALE', defaultValue: false, description: 'This variable will scale the cluster up one node at the end up the ugprade')
         string(name: 'LOADED_JOB_URL', defaultValue: '', description: 'Upgrade job url')
         string(name: 'CI_STATUS', defaultValue: 'FAIL', description: 'Scale-ci job ending status')
+        string(name: 'JOB_PARAMETERS', defaultValue: '', description:'These are the parametes that were run for the specific scale-ci job')
+        text(name: 'JOB_OUTPUT', defaultValue: '', description:'This is the output that was run from the scale-ci job. This will be used to help get comparison sheets')
         string(name:'JENKINS_AGENT_LABEL',defaultValue:'oc45',description:
         '''
         scale-ci-static: for static agent that is specific to scale-ci, useful when the jenkins dynamic agent isn't stable
@@ -95,7 +97,8 @@ pipeline {
             elif [[ $JOB == "upgrade" ]]; then
                 python -c "import write_to_sheet; write_to_sheet.write_to_sheet('$GSHEET_KEY_LOCATION', ${params.BUILD_NUMBER}, '${params.UPGRADE_JOB_URL}', '${params.CI_STATUS}', '${params.SCALE}', '${params.ENABLE_FORCE}')"
             else
-                python -c "import write_scale_results_sheet; write_scale_results_sheet.write_to_sheet('$GSHEET_KEY_LOCATION', ${params.BUILD_NUMBER},  '${params.CI_JOB_ID}', '${params.JOB}', '${params.CI_JOB_URL}', '${params.CI_STATUS}')"
+                echo "$JOB_OUTPUT" >> output_file.out
+                python -c "import write_scale_results_sheet; write_scale_results_sheet.write_to_sheet('$GSHEET_KEY_LOCATION', ${params.BUILD_NUMBER},  '${params.CI_JOB_ID}', '${params.JOB}', '${params.CI_JOB_URL}', '${params.CI_STATUS}', '${params.JOB_PARAMETERS}', 'output_file.out')"
             fi
             rm -rf ~/.kube
             """

--- a/write_to_sheet/get_scale_output.py
+++ b/write_to_sheet/get_scale_output.py
@@ -1,0 +1,30 @@
+import write_helper
+import yaml
+
+def get_output(job_type):
+    if job_type == "etcd-perf":
+        return get_99_latency()
+    else:
+        return 0
+
+# No longer need to get job iterations, going to pass from kube-burner job
+def get_kube_burner_config():
+    return_code, configmap_name = write_helper.run('oc get configmap -n benchmark-operator -o name --sort-by "{.metadata.creationTimestamp}" --no-headers| grep "kube-burner" | tail -n 1')
+    return_code, config_yaml = write_helper.run("oc get %s -n benchmark-operator -o jsonpath='{.data.config\.yml}'" % configmap_name.strip())
+    config_jobs = config_yaml.split("jobs")
+    print('jobs ' +str(config_jobs[1]))
+    config_job_yaml = yaml.safe_load(config_jobs[1][2:])
+    print("jobIterations" + str(config_job_yaml[0]['jobIterations']))
+    return config_job_yaml[0]['jobIterations']
+
+def get_99_latency():
+    return_code, str_uuid = write_helper.run("oc get benchmark -n benchmark-operator etcd-fio -o 'jsonpath={.status.uuid}'")
+    uuid = str_uuid.split("=")[-1]
+    json_to_find = '{"_source": false, "aggs": {"max-fsync-lat-99th": {"max": {"field": "fio.sync.lat_ns.percentile.99.000000"}}}}'
+
+    return_code, es_url = write_helper.run("oc get benchmark -n benchmark-operator etcd-fio -o 'jsonpath={.spec.elasticsearch.url}'")
+    return_code, latency = write_helper.run(f"curl -s '{es_url}/ripsaw-fio-results/_search?q=uuid:{uuid}' -H 'Content-Type: application/json' -d '{json_to_find}'")
+    latency_yaml = yaml.safe_load(latency)
+    val_99 = latency_yaml['aggregations']['max-fsync-lat-99th']["value"]
+    return val_99
+

--- a/write_to_sheet/uperf_find_uuid.json
+++ b/write_to_sheet/uperf_find_uuid.json
@@ -1,0 +1,73 @@
+{
+    "version": true,
+    "size": 500,
+    "sort": [
+        {
+            "uperf_ts": {
+                "order": "desc",
+                "unmapped_type": "boolean"
+            }
+        }
+    ],
+    "aggs": {
+        "2": {
+            "date_histogram": {
+                "field": "uperf_ts",
+                "fixed_interval": "30m",
+                "time_zone": "America/New_York",
+                "min_doc_count": 1
+            }
+        }
+    },
+    "stored_fields": [
+        "*"
+    ],
+    "script_fields": {},
+    "docvalue_fields": [
+        {
+            "field": "uperf_ts",
+            "format": "date_time"
+        }
+    ],
+    "_source": {
+        "excludes": []
+    },
+    "query": {
+        "bool": {
+            "must": [],
+            "filter": [
+                {
+                    "match_all": {}
+                },
+                {
+                    "match_phrase": {
+                        "cluster_name": "qe-pr-10899-kdl2n-oa"
+                    }
+                },
+                {
+                    "range": {
+                        "uperf_ts": {
+                            "gte": "2022-03-18T14:13:57Z",
+                            "lte": "2022-03-18T15:22:09.424Z",
+                            "format": "strict_date_optional_time"
+                        }
+                    }
+                }
+            ],
+            "should": [],
+            "must_not": []
+        }
+    },
+    "highlight": {
+        "pre_tags": [
+            "@kibana-highlighted-field@"
+        ],
+        "post_tags": [
+            "@/kibana-highlighted-field@"
+        ],
+        "fields": {
+            "*": {}
+        },
+        "fragment_size": 2147483647
+    }
+}

--- a/write_to_sheet/write_helper.py
+++ b/write_to_sheet/write_helper.py
@@ -63,6 +63,20 @@ def get_pod_latencies():
         return avg_list
     return ["", "", "", ""]
 
+
+def get_uperf_uuid():
+    # In the form of [[json_data['quantileName'], json_data['avg'], json_data['P99']...]
+    pod_latencies_list = get_es_data.get_pod_latency_data()
+    if len(pod_latencies_list) != 0:
+        print("Pod latency list {}".format(str(pod_latencies_list)))
+        avg_list = []
+        p99_list = []
+        for pod_info in pod_latencies_list:
+            avg_list.append(pod_info[1])
+            p99_list.append(pod_info[2])
+        return avg_list
+    return ["", "", "", ""]
+
 def get_oc_version():
     return_code, cluster_version_str = run("oc get clusterversion -o json")
     if return_code == 0:


### PR DESCRIPTION
Previously network-perf and sometimes etcd-perf did not write to the google sheet at all. This adds in printing off of important information for each of those tests as well as parameters from the previous jobs 

In network-perf, printing off the google sheet that gets created 

In etcd-perf, printing off the 99% latency 

https://docs.google.com/spreadsheets/d/1uiKGYQyZ7jxchZRU77lsINpa23HhrFWjphsqGjTD-u4/edit?usp=sharing

These 2 new parameters will also need changes in kube-burner and network-perf as well. Will open those PR's soon and link to this one
