### PR TITLE
Getting status of python script not tee

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -150,6 +150,7 @@ pipeline {
           elif [[ $WORKLOAD == "node-density" ]] || [[ $WORKLOAD == "node-density-heavy" ]]; then
             export PODS_PER_NODE=$VARIABLE
           fi
+          set -o pipefail
           ./run.sh | tee "kube-burner.out"
           ''')
           output = sh(returnStdout: true, script: 'cat workloads/kube-burner/kube-burner.out')


### PR DESCRIPTION
Need to set proper status based on only the response of the run script not of if "tee" completed properly 

Examples of a job that actually failed but passed overall
[Passed job](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/kube-burner/90/console)

Used this doc: https://stackoverflow.com/questions/6871859/piping-command-output-to-tee-but-also-save-exit-code-of-command

Job now with correct failure status: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/paige-e2e-multibranch/job/kube-status/3/console

CC: @nathan-weinberg 