### PR TITLE
Adding getting pod averages in error cases

### DIFF
--- a/write_to_sheet/write_helper.py
+++ b/write_to_sheet/write_helper.py
@@ -29,39 +29,36 @@ def get_upgrade_duration():
                 start_time = hist['startedTime']
                 if not hist['completionTime']:
                     latestCompletiontime = datetime.now()
-                    print("Setting completion time to now")
+
                 else:
                     end_time = hist['completionTime']
                     end_date_time = datetime.strptime(end_time[:-1], "%Y-%m-%dT%H:%M:%S")
                     if end_date_time > latestCompletiontime:
-                        print("Last completion {}".format(str(end_date_time)))
+
                         latestCompletiontime = end_date_time
 
                 start_date_time = datetime.strptime(start_time[:-1], "%Y-%m-%dT%H:%M:%S")
                 if (start_date_time < earliesetStartingTime) and lastVersion:
-                    print('Earliest date re-set to {}'.format(str(start_date_time)))
                     earliesetStartingTime = start_date_time
 
         time_elapsed = latestCompletiontime - earliesetStartingTime
-
-        print("Time elapsed {}".format(str(time_elapsed)))
-        print('All versions in upgrade {}'.format(str(all_versions)))
         all_versions.reverse()
         return str(time_elapsed), all_versions
     return get_oc_version(), ""
 
-def get_pod_latencies():
-    # In the form of [[json_data['quantileName'], json_data['avg'], json_data['P99']...]
-    pod_latencies_list = get_es_data.get_pod_latency_data()
-    if len(pod_latencies_list) != 0:
-        print("Pod latency list {}".format(str(pod_latencies_list)))
-        avg_list = []
-        p99_list = []
-        for pod_info in pod_latencies_list:
-            if len(pod_info) > 0:
-                avg_list.append(pod_info[1])
-                p99_list.append(pod_info[2])
-        return avg_list
+def get_pod_latencies(uuid):
+    if uuid != "":
+        # In the form of [[json_data['quantileName'], json_data['avg'], json_data['P99']...]
+        pod_latencies_list = get_es_data.get_pod_latency_data(uuid)
+        if len(pod_latencies_list) != 0:
+            avg_list = []
+            p99_list = []
+
+            for pod_info in pod_latencies_list:
+                if len(pod_info) > 0:
+                    avg_list.append(pod_info[1])
+                    p99_list.append(pod_info[2])
+            return avg_list
     return ["", "", "", ""]
 
 
@@ -69,7 +66,6 @@ def get_uperf_uuid():
     # In the form of [[json_data['quantileName'], json_data['avg'], json_data['P99']...]
     pod_latencies_list = get_es_data.get_pod_latency_data()
     if len(pod_latencies_list) != 0:
-        print("Pod latency list {}".format(str(pod_latencies_list)))
         avg_list = []
         p99_list = []
         for pod_info in pod_latencies_list:
@@ -86,7 +82,6 @@ def get_oc_version():
             for status in item['status']['conditions']:
                 if status['type'] == "Progressing":
                     version = status['message'].split(" ")[-1]
-                    print('version {}'.format(str(version)))
                     return version
     else:
         print("Error getting clusterversion")
@@ -94,9 +89,7 @@ def get_oc_version():
 def flexy_install_type(flexy_url):
     return_code, version_type_string = run('curl -s {}/consoleFull | grep "run_installer template -c private-templates/functionality-testing/aos-"'.format(flexy_url))
     if return_code == 0:
-        print("version_tpye " + str(version_type_string))
         version_lists = version_type_string.split("-on-")
-        print('version_lists {}'.format(str(version_lists)))
         install_type = version_lists[0].split('/')[-1]
         cloud_type = version_lists[1].split('/')[0]
         if "ovn" in version_type_string:

--- a/write_to_sheet/write_scale_results_sheet.py
+++ b/write_to_sheet/write_scale_results_sheet.py
@@ -167,7 +167,8 @@ def write_to_sheet(google_sheet_account, flexy_id, ci_job, job_type, job_url, st
     row = [version, flexy_cell, ci_cell, grafana_cell, status]
     if job_type not in ["network-perf", "router-perf"]:
         workload_args = get_workload_params(job_type)
-        if workload_args != 0 and job_parameters:
+        print('work')
+        if workload_args != 0:
             row.append(workload_args)
     elif job_type == "router-perf":
         row.append(str(metadata))
@@ -189,4 +190,4 @@ def write_to_sheet(google_sheet_account, flexy_id, ci_job, job_type, job_url, st
     row.append(str(datetime.now(tz)))
     ws.insert_row(row, index, "USER_ENTERED")
 
-#write_to_sheet("/Users/prubenda/.secrets/perf_sheet_service_account.json", 96155, 117, 'pod-density', "https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/kube-burner/117/", "FAIL","400", "network_perf.out")
+#write_to_sheet("/Users/prubenda/.secrets/perf_sheet_service_account.json", 97141, 70, 'etcd-perf', "https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/etcd-perf/70/", "FAIL","", "")


### PR DESCRIPTION
Currently when the kube-burner tests finish it cleans up the benchmark-operator namespace and all objects that I was using to get the pod ready latencies. I have added in back up ways to get the UUID from the output but now need to pass it to be able to get the pod latencies of the job properly

I created a PR to only cleanup the namespace if you want to cleanup all the objects as well
https://github.com/cloud-bulldozer/e2e-benchmarking/pull/381