### PR TITLE
add INFRA_WORKLOAD_INSTALL to router-perf

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,6 +52,7 @@ pipeline {
                </p><br>
                check <a href="https://github.com/cloud-bulldozer/e2e-benchmarking/tree/master/workloads/router-perf-v2">Router perf readme</a> for more env vars you can set'''
             )
+        booleanParam(name: 'INFRA_WORKLOAD_INSTALL', defaultValue: false, description: 'Install workload and infrastructure nodes even if less than 50 nodes. <br> Checking this parameter box is valid only when SCALE_UP is greater than 0.')
         string(name: 'SCALE_UP', defaultValue: '0', description: 'If value is set to anything greater than 0, cluster will be scaled up before executing the workload.')
         string(name: 'SCALE_DOWN', defaultValue: '0', description:
         '''If value is set to anything greater than 0, cluster will be scaled down after the execution of the workload is complete,<br>
@@ -70,7 +71,7 @@ pipeline {
       steps{
         script{
           if(params.SCALE_UP.toInteger() > 0) {
-            build job: 'scale-ci/e2e-benchmarking-multibranch-pipeline/cluster-workers-scaling', parameters: [string(name: 'BUILD_NUMBER', value: BUILD_NUMBER), text(name: "ENV_VARS", value: ENV_VARS), string(name: 'WORKER_COUNT', value: SCALE_UP), string(name: 'JENKINS_AGENT_LABEL', value: JENKINS_AGENT_LABEL)]
+            build job: 'scale-ci/e2e-benchmarking-multibranch-pipeline/cluster-workers-scaling', parameters: [string(name: 'BUILD_NUMBER', value: BUILD_NUMBER), text(name: "ENV_VARS", value: ENV_VARS), string(name: 'WORKER_COUNT', value: SCALE_UP), string(name: 'JENKINS_AGENT_LABEL', value: JENKINS_AGENT_LABEL), booleanParam(name: 'INFRA_WORKLOAD_INSTALL', value: INFRA_WORKLOAD_INSTALL)]
           }
         }
         deleteDir()
@@ -109,6 +110,7 @@ pipeline {
               ls -ls ~/.kube/
               env
               cd workloads/router-perf-v2
+              set -o pipefail
               ./ingress-performance.sh | tee "router-perf-v2.out"
               rm -rf ~/.kube
               ''')

--- a/README.md
+++ b/README.md
@@ -6,5 +6,6 @@
 Run Router Perf Tests workload on a given OpenShift cluster. OpenShift cluster `kubeconfig` is fetched from given flexy job id.
 
 
-### Author
-Kedar Kulkarni <@kedark3 on Github>
+### Contacts
+Qiujie Li <@qiliRedHat on Github>
+Paige Rubendall <@paigerube14 on Github>


### PR DESCRIPTION
Router-perf job has no check box of INFRA_WORKLOAD_INSTALL yet, add it.
Tested with job:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/qili-e2e-benchmark/job/router-perf/5
Machinesets created after job run:
```
% oc get machinesets -A
NAMESPACE               NAME                                     DESIRED   CURRENT   READY   AVAILABLE   AGE
openshift-machine-api   infra-us-east-2a                         1         1         1       1           22m
openshift-machine-api   infra-us-east-2b                         1         1         1       1           22m
openshift-machine-api   infra-us-east-2c                         1         1         1       1           22m
openshift-machine-api   qili-41011-aws-ntxmx-worker-us-east-2a   40        40        40      40          79m
openshift-machine-api   qili-41011-aws-ntxmx-worker-us-east-2b   40        40        40      40          79m
openshift-machine-api   qili-41011-aws-ntxmx-worker-us-east-2c   40        40        40      40          79m
openshift-machine-api   workload-us-east-2a                      1         1         1       1           22m
```