### PR TITLE
Propogate false for write to sheet in network perf

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,7 +128,16 @@ pipeline {
                 currentBuild.result = "FAILURE"
             }
            if(params.WRITE_TO_FILE == true) {
-            build job: 'scale-ci/e2e-benchmarking-multibranch-pipeline/write-scale-ci-results', parameters: [string(name: 'BUILD_NUMBER', value: BUILD_NUMBER), string(name: 'CI_JOB_ID', value: BUILD_ID), string(name: 'CI_JOB_URL', value: BUILD_URL), text(name: "ENV_VARS", value: ENV_VARS), string(name: 'JENKINS_AGENT_LABEL', value: JENKINS_AGENT_LABEL), string(name: "CI_STATUS", value: "${status}"), string(name: "JOB", value: "network-perf"),, string(name: "JOB_PARAMETERS", value: "${parameter_to_pass}" ), text(name: "JOB_OUTPUT", value: "${output}")]
+            build job: 'scale-ci/e2e-benchmarking-multibranch-pipeline/write-scale-ci-results',
+                parameters: [
+                    string(name: 'BUILD_NUMBER', value: BUILD_NUMBER), string(name: 'CI_JOB_ID', value: BUILD_ID),
+                    string(name: 'CI_JOB_URL', value: BUILD_URL), text(name: "ENV_VARS", value: ENV_VARS),
+                    string(name: 'JENKINS_AGENT_LABEL', value: JENKINS_AGENT_LABEL),
+                    string(name: "CI_STATUS", value: "${status}"), string(name: "JOB", value: "network-perf"),
+                     string(name: "JOB_PARAMETERS", value: "${parameter_to_pass}" ),
+                     text(name: "JOB_OUTPUT", value: "${output}")
+                ],
+                propagate: false
            }
         }
         script{


### PR DESCRIPTION
Adding propogate false to network-perf write to sheet to not have the pass/fail status of write to sheet effect the overall network-perf test status 