### PR TITLE
Adding cleanup script for specific jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,119 @@
+@Library('flexy') _
+
+// rename build
+def userId = currentBuild.rawBuild.getCause(hudson.model.Cause$UserIdCause)?.userId
+if (userId) {
+  currentBuild.displayName = userId
+}
+
+def RETURNSTATUS = "default"
+
+pipeline {
+  agent none
+
+  parameters {
+        string(name: 'BUILD_NUMBER', defaultValue: '', description: 'Build number of job that has installed the cluster.')
+        string(name: 'CI_TYPE', defaultValue: '', description: 'Type of job you ran and want to cleanup. Ex. node-density')
+        booleanParam(name: 'UNINSTALL_BENCHMARK_OP', defaultValue: false, description: 'This variable will uninstall the benchmark-operator if true')
+        string(name:'JENKINS_AGENT_LABEL',defaultValue:'oc45',description:
+        '''
+        scale-ci-static: for static agent that is specific to scale-ci, useful when the jenkins dynamic agent isn't stable<br>
+        4.y: oc4y || mac-installer || rhel8-installer-4y <br/>
+            e.g, for 4.8, use oc48 || mac-installer || rhel8-installer-48 <br/>
+        3.11: ansible-2.6 <br/>
+        3.9~3.10: ansible-2.4 <br/>
+        3.4~3.7: ansible-2.4-extra || ansible-2.3 <br/>
+        '''
+        )
+       text(name: 'ENV_VARS', defaultValue: '', description:'''<p>
+               Enter list of additional (optional) Env Vars you'd want to pass to the script, one pair on each line. <br>
+               e.g.<br>
+               SOMEVAR1='env-test'<br>
+               SOMEVAR2='env2-test'<br>
+               ...<br>
+               SOMEVARn='envn-test'<br>
+               </p>'''
+            )
+        string(name: 'BENCHMARK_OP_REPO', defaultValue:'https://github.com/cloud-bulldozer/benchmark-operator.git', description:'You can change this to point to your fork if needed.')
+        string(name: 'BENCHMARK_OP_REPO_BRANCH', defaultValue:'master', description:'You can change this to point to a branch on your fork if needed.')
+    }
+
+  stages {
+    stage('Run CI Cleanup'){
+      agent { label params['JENKINS_AGENT_LABEL'] }
+      steps{
+        deleteDir()
+        checkout([
+          $class: 'GitSCM',
+          branches: [[name: GIT_BRANCH ]],
+          doGenerateSubmoduleConfigurations: false,
+          userRemoteConfigs: [[url: GIT_URL ]
+          ]])
+
+        copyArtifacts(
+            filter: '',
+            fingerprintArtifacts: true,
+            projectName: 'ocp-common/Flexy-install',
+            selector: specific(params.BUILD_NUMBER),
+            target: 'flexy-artifacts'
+        )
+        script {
+          buildinfo = readYaml file: "flexy-artifacts/BUILDINFO.yml"
+          currentBuild.displayName = "${currentBuild.displayName}-${params.BUILD_NUMBER}"
+          currentBuild.description = "Copying Artifact from Flexy-install build <a href=\"${buildinfo.buildUrl}\">Flexy-install#${params.BUILD_NUMBER}</a>"
+          buildinfo.params.each { env.setProperty(it.key, it.value) }
+        }
+        script {
+          sh(script: '''
+          # Get ENV VARS Supplied by the user to this job and store in .env_override
+          echo "$ENV_VARS" > .env_override
+          # Export those env vars so they could be used by CI Job
+          set -a && source .env_override && set +a
+          mkdir -p ~/.kube
+          cp $WORKSPACE/flexy-artifacts/workdir/install-dir/auth/kubeconfig ~/.kube/config
+          oc config view
+          oc projects
+          ls -ls ~/.kube/
+          env
+          echo "$OSTYPE"
+          export PYTHONUNBUFFERED=1
+          python -c "import cleanup; cleanup.delete_all_namespaces('$CI_TYPE')"
+          if [ $UNINSTALL_BENCHMARK_OP == true ]; then
+              wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tgz
+              tar -zxvf Python-3.8.12.tgz
+              cd Python-3.8.12
+              newdirname=~/.localpython
+              if [ -d "$newdirname" ]; then
+                echo "Directory already exists"
+              else
+                mkdir -p $newdirname
+                ./configure --prefix=$HOME/.localpython
+                make
+                make install
+              fi
+              python_folder="bin/python3"
+              if [ -d "$newdirname/bin/python3" ]; then
+                echo "Directory python3 "
+              elif [ -d "$newdirname/bin/python3.8" ]; then
+                echo "Directory python3.8 "
+                python_folder="bin/python3.8"
+              fi
+              $HOME/.localpython/$python_folder --version
+              python3 -m pip install virtualenv --user
+              python3 -m virtualenv venv3 -p $HOME/.localpython/$python_folder
+              source venv3/bin/activate
+              python --version
+              pip install -U "git+https://github.com/cloud-bulldozer/benchmark-operator.git/#egg=ripsaw-cli&subdirectory=cli"
+              ripsaw operator delete --repo=$BENCHMARK_OP_REPO --branch=$BENCHMARK_OP_REPO_BRANCH
+          else
+            python3 -c "import cleanup; cleanup.delete_all_jobs()"
+            python3 -c "import cleanup; cleanup.delete_all_benchmarks()"
+          fi
+
+          ''')
+        }
+
+     }
+  }
+}
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# E2E Benchmarking CI Repo - Benchmark Cleaner
+
+## Purpose
+Want to cleanup namespaces created by e2e-benchmarking after test is finished, mostly used for kube-burner workloads
+
+
+NOTE: Network-perf and router-perf cleanup both the namespaces and benchmark-operator at the end of their runs
+ 
+
+### Parameters
+BUILD_NUMBER: flexy id of cluster to cleanup on 
+
+CI_TYPE: type of workload that was run to create namespaces (Ex. node-density, pod-density)
+
+UNINSTALL_BENCHMARK_OP: uninstall the benchmark-operator namespace and all of its sub objects 
+
+### Author
+Paige Rubendall <@paigerube14 on Github>

--- a/cleanup.py
+++ b/cleanup.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+import time
+import yaml
+import subprocess
+import sys
+import json
+
+# Invokes a given command and returns the stdout
+def invoke(command):
+    try:
+
+        output = subprocess.check_output(command, shell=True, universal_newlines=True)
+    except subprocess.CalledProcessError as exc:
+        print("Status : FAIL", exc.returncode, exc.output)
+        return exc.returncode, exc.output
+    print("Status : ",  output)
+    return 0, output
+
+def delete_all_benchmarks():
+    invoke("oc delete benchmark -n benchmark-operator --all")
+
+def delete_all_jobs():
+    invoke("oc delete jobs -n benchmark-operator --all")
+
+def delete_all_namespaces(job):
+    # make sure all namespaces are gone
+    print("job type " + str(job))
+    if job.lower() == "pod-density":
+        job = "node-density"
+    invoke("oc delete ns --wait=false -l kube-burner-job=" + job)
+    wait_for_all_deleted_ns(job)
+
+def wait_for_all_deleted_ns(job, wait_num=300):
+    counter = 0
+    ns_left = 1000  # starting at random high number
+    while int(ns_left) > 0:
+        returncode, ns_left = invoke("oc get ns --no-headers | grep Terminating | wc -l")
+        ns_left = ns_left.strip()
+        print(ns_left + " namespaces are left to still terminate")
+        if counter > wait_num:
+            print("Namespaces created by kube burner job " + job + " still have not terminated properly")
+            return 1
+        counter += 1
+        print("waiting 10 seconds and repolling")
+        time.sleep(10)
+    invoke("oc get ns")
+    return 0
+


### PR DESCRIPTION
Resolves OCPQE-9127

Adding cleanup script for CI usage. Takes in the workload type to be able to delete namespace that were created during the kube-burner run. Also have the option to delete benchmark-operator namespace and objects if they exist

Example: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/paige-e2e-multibranch/job/cleanup/69/console