### PR TITLE
Adding getting pod averages in error cases by time in job output

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,4 @@
 Write Scale CI Results to Spreadsheets
 
 ### Author
-Kedar Kulkarni <@kedark3 on Github>
 Paige Rubendall <@paigerube14 on GitHub>

--- a/write_to_sheet/write_helper.py
+++ b/write_to_sheet/write_helper.py
@@ -7,7 +7,7 @@ def run(command):
     try:
         output = subprocess.check_output(command, shell=True, universal_newlines=True)
     except subprocess.CalledProcessError as exc:
-        print("Status : FAIL", exc.returncode, exc.output)
+        print("Status : ", command, exc.output)
         return exc.returncode, exc.output
     return 0, output
 
@@ -46,10 +46,10 @@ def get_upgrade_duration():
         return str(time_elapsed), all_versions
     return get_oc_version(), ""
 
-def get_pod_latencies(uuid):
+def get_pod_latencies(uuid="",creation_time=""):
     if uuid != "":
         # In the form of [[json_data['quantileName'], json_data['avg'], json_data['P99']...]
-        pod_latencies_list = get_es_data.get_pod_latency_data(uuid)
+        pod_latencies_list = get_es_data.get_pod_latency_data(uuid, creation_time)
         if len(pod_latencies_list) != 0:
             avg_list = []
             p99_list = []
@@ -59,19 +59,6 @@ def get_pod_latencies(uuid):
                     avg_list.append(pod_info[1])
                     p99_list.append(pod_info[2])
             return avg_list
-    return ["", "", "", ""]
-
-
-def get_uperf_uuid():
-    # In the form of [[json_data['quantileName'], json_data['avg'], json_data['P99']...]
-    pod_latencies_list = get_es_data.get_pod_latency_data()
-    if len(pod_latencies_list) != 0:
-        avg_list = []
-        p99_list = []
-        for pod_info in pod_latencies_list:
-            avg_list.append(pod_info[1])
-            p99_list.append(pod_info[2])
-        return avg_list
     return ["", "", "", ""]
 
 def get_oc_version():

--- a/write_to_sheet/write_loaded_results.py
+++ b/write_to_sheet/write_loaded_results.py
@@ -1,6 +1,5 @@
 from oauth2client.service_account import ServiceAccountCredentials
 import gspread
-
 from datetime import datetime
 from pytz import timezone
 import write_helper
@@ -52,7 +51,6 @@ def write_to_sheet(google_sheet_account, flexy_id, scale_ci_job, upgrade_job_url
     last_version = versions[-1].split(".")
     row = [flexy_cell, versions[0], upgrade_path_cell, ci_cell, worker_count, status_cell, duration,scale, force,
            cloud_type, install_type, network_type, sno, str(datetime.now(tz))]
-    row.extend(write_helper.get_pod_latencies())
     upgrade_sheet = file.open_by_url(
         "https://docs.google.com/spreadsheets/d/1yqQxAxLcYEF-VHlQ_KDLs8NOFsRLb4R8V2UM9VFaRBI/edit?usp=sharing")
     ws_upgrade = upgrade_sheet.worksheet(str(last_version[0]) + "." + str(last_version[1]))

--- a/write_to_sheet/write_nightly_results.py
+++ b/write_to_sheet/write_nightly_results.py
@@ -15,8 +15,6 @@ def write_to_sheet(google_sheet_account, flexy_id, scale_ci_job, ran_jobs, faile
 
     sheet = file.open_by_url("https://docs.google.com/spreadsheets/d/1Zp116e0goej2Q8TOF6o9AwsXbWd-WqCsmwhFA1SFdIk/edit?usp=sharing")
 
-    ws = sheet.worksheet("Nightly Scale-CI")
-
     index = 2
     flexy_url = f"https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Flexy-install/{flexy_id}"
     cloud_type, install_type, network_type = write_helper.flexy_install_type(flexy_url)
@@ -37,7 +35,8 @@ def write_to_sheet(google_sheet_account, flexy_id, scale_ci_job, ran_jobs, faile
     cluster_version = write_helper.get_oc_version()
     tz = timezone('EST')
     row = [flexy_cell, cluster_version, cloud_type, install_type, network_type, worker_count, ci_cell, failed_jobs, str(datetime.now(tz)), status]
-
+    ws = sheet.worksheet("Nightly Scale-CI")
     ws.insert_row(row, index, "USER_ENTERED")
-
+    ws = sheet.worksheet(str(last_version[0]) + "." + str(last_version[1]))
+    ws.insert_row(row, index, "USER_ENTERED")
 #write_to_sheet("/Users/prubenda/.secrets/perf_sheet_service_account.json", "93505", "https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/scale-profile-regression/30/console", "['pod-density','node-density']", "['node-density']", "TEST")


### PR DESCRIPTION
Updating getting uuid and pod latencies timing by using creation time in the job output parameter passed. 

Fixes writing out for network-perf and concurrent-builds