### PR TITLE
Netobserv 332

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,7 +123,7 @@ pipeline {
 
         checkout([
           $class: 'GitSCM', 
-          branches: [[name: "NETOBSERV-332" ]],
+          branches: [[name: "netobserv-perf-tests" ]],
           doGenerateSubmoduleConfigurations: false, 
           userRemoteConfigs: [[url: "https://github.com/memodi/ocp-qe-perfscale-ci" ]],
           extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'ocp-qe-perfscale']]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,10 @@ pipeline {
             for agents with go tools, use goc48, goc49 etc. <br/> 
         '''
         )
+
+        choice(name: 'Deploy_NetObserv', choices: ['OperatorHub', 'main', 'None'], description: '''Option to Deploy netobserv from main or OperatorHub release, select one.<br>
+            If none selected tests will run without NetObserv deployed <br/>''')
+
         text(name: 'ENV_VARS', defaultValue: '', description:'''<p>
                Enter list of additional (optional) Env Vars you'd want to pass to the script, one pair on each line. <br>
                e.g.<br>
@@ -119,7 +123,7 @@ pipeline {
 
         checkout([
           $class: 'GitSCM', 
-          branches: [[name: "netobserv-perf-tests" ]],
+          branches: [[name: "NETOBSERV-332" ]],
           doGenerateSubmoduleConfigurations: false, 
           userRemoteConfigs: [[url: "https://github.com/memodi/ocp-qe-perfscale-ci" ]],
           extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'ocp-qe-perfscale']]
@@ -154,9 +158,9 @@ pipeline {
             ls -ls ~/.kube/
             env
             ls -al
-            wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tgz
-            tar -zxvf Python-3.8.12.tgz
-            cd Python-3.8.12
+            wget https://www.python.org/ftp/python/3.9.12/Python-3.9.12.tgz
+            tar -zxvf Python-3.9.12.tgz
+            cd Python-3.9.12
             newdirname=~/.localpython
             if [ -d "$newdirname" ]; then
               echo "Directory already exists"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,3 +14,16 @@ The Network Observability Prometheus and Elasticsearch tool, or NOPE, is a Pytho
 2. Install requirements with `pip install -r scripts/requirements.txt`
 3. Set your `kubeconfig` and login to your cluster as `kubeadmin`
 4. Run the tool with `./scripts/nope.py`
+
+
+## Metrics Collection
+Below are the metrics that are collected as part of the tests:
+* CPU usage of pods in network-observability NS
+* Memory usage of pods in network-observability NS
+* Disk usage for PVC=loki-store
+* Number of NetFlows processed
+* Flow Processing time summary for 0.9 quantile
+* Total sum of number of bytes 
+* Summary of packet size within Flows
+* Number of log lines (flow logs) processed
+

--- a/scripts/cluster-monitoring-config.yaml
+++ b/scripts/cluster-monitoring-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -14,6 +14,6 @@ populate_netobserv_metrics() {
 prep_kubeburner_workload() {
     export METRICS_PROFILE=$PWD/netobserv-metrics.yaml
     export THANOS_QUERIER_HOST=$(oc get route thanos-querier -n openshift-monitoring -o json | jq -r '.spec.host')
-    export PROM_URL="https://$THANOS_QUERIER_HOST"
+    export PROM_URL="https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"
     export PROM_USER_WORKLOAD="true"
 }

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -13,4 +13,7 @@ populate_netobserv_metrics() {
 
 prep_kubeburner_workload() {
     export METRICS_PROFILE=$PWD/netobserv-metrics.yaml
+    export THANOS_QUERIER_HOST=$(oc get route thanos-querier -n openshift-monitoring -o json | jq -r '.spec.host')
+    export PROM_URL="https://$THANOS_QUERIER_HOST"
+    export PROM_USER_WORKLOAD="true"
 }

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -4,3 +4,13 @@ prep_uperf_workload() {
     envsubst '${PAIRS} ${SAMPLES} ${PROTOCOL} ${TRAFFIC_TYPE} ${PACKET_SIZE}' <ripsaw-uperf-crd.yaml >$NETWORK_PERF_DIR/ripsaw-uperf-crd.yaml
     cat $NETWORK_PERF_DIR/ripsaw-uperf-crd.yaml
 }
+
+populate_netobserv_metrics() {
+    oc apply -f cluster-monitoring-config.yaml
+    oc apply -f service-monitor.yaml
+    log "Added ServiceMonitor for NetObserv prometheus metrics"
+}
+
+prep_kubeburner_workload() {
+    export METRICS_PROFILE=$PWD/netobserv-metrics.yaml
+}

--- a/scripts/flows_v1alpha1_flowcollector_versioned.yaml
+++ b/scripts/flows_v1alpha1_flowcollector_versioned.yaml
@@ -20,8 +20,6 @@ spec:
     logLevel: info
   flowlogsPipeline:
     kind: DaemonSet
-#    kind: Deployment
-#    replicas: 1
     port: 2055
     image: 'quay.io/netobserv/flowlogs-pipeline:v0.1.1'
     imagePullPolicy: IfNotPresent

--- a/scripts/flows_v1alpha1_flowcollector_versioned.yaml
+++ b/scripts/flows_v1alpha1_flowcollector_versioned.yaml
@@ -1,0 +1,53 @@
+apiVersion: flows.netobserv.io/v1alpha1
+kind: FlowCollector
+metadata:
+  name: cluster
+spec:
+  namespace: "network-observability"
+  agent: ipfix
+  ipfix:
+    cacheActiveTimeout: 60s
+    cacheMaxFlows: 100
+    sampling: ${FLOW_SAMPLING}
+  ebpf:
+    image: 'quay.io/netobserv/netobserv-ebpf-agent:v0.1.0'
+    imagePullPolicy: IfNotPresent
+    sampling: 0
+    cacheActiveTimeout: 5s
+    cacheMaxFlows: 1000
+    interfaces: []
+    excludeInterfaces: ["lo"]
+    logLevel: info
+  flowlogsPipeline:
+    kind: DaemonSet
+#    kind: Deployment
+#    replicas: 1
+    port: 2055
+    image: 'quay.io/netobserv/flowlogs-pipeline:v0.1.1'
+    imagePullPolicy: IfNotPresent
+    logLevel: info
+    enableKubeProbes: true
+    healthPort: 8080
+    prometheusPort: 9090
+  loki:
+    url: 'http://loki:3100/'
+    batchWait: 1s
+    batchSize: 102400
+    minBackoff: 1s
+    maxBackoff: 300s
+    maxRetries: 10
+    timestampLabel: TimeFlowEnd
+    staticLabels:
+      app: netobserv-flowcollector
+  consolePlugin:
+    register: true
+    image: 'quay.io/netobserv/network-observability-console-plugin:v0.1.2'
+    imagePullPolicy: IfNotPresent
+    port: 9001
+    logLevel: info
+    portNaming:
+      enable: true
+      portNames:
+        "3100": loki
+  clusterNetworkOperator:
+    namespace: "openshift-network-operator"

--- a/scripts/loki-storage-1.yaml
+++ b/scripts/loki-storage-1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: loki-store
+  namespace: network-observability
+spec:
+  resources:
+    requests:
+      storage: 1G
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+

--- a/scripts/loki-storage-2.yaml
+++ b/scripts/loki-storage-2.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+  namespace: network-observability
+data:
+  local-config.yaml: |
+    auth_enabled: false
+    server:
+      http_listen_port: 3100
+      grpc_listen_port: 9096
+    common:
+      path_prefix: /loki-store
+      storage:
+        filesystem:
+          chunks_directory: /loki-store/chunks
+          rules_directory: /loki-store/rules
+      replication_factor: 1
+      ring:
+        instance_addr: 127.0.0.1
+        kvstore:
+          store: inmemory
+    schema_config:
+      configs:
+        - from: 2020-10-24
+          store: boltdb-shipper
+          object_store: filesystem
+          schema: v11
+          index:
+            prefix: index_
+            period: 24h
+    storage_config:
+      filesystem:
+        directory: /loki-store/storage
+      boltdb_shipper:
+        active_index_directory: /loki-store/index
+        shared_store: filesystem
+        cache_location: /loki-store/boltdb-cache
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: loki
+  labels:
+    app: loki
+  namespace: network-observability
+spec:
+  securityContext:
+    runAsGroup: 1000
+    runAsUser: 1000
+    fsGroup: 1000
+  volumes:
+    - name: loki-store
+      persistentVolumeClaim:
+        claimName: loki-store
+    - name: loki-config
+      configMap:
+        name: loki-config
+  containers:
+    - name: loki
+      image: grafana/loki:2.4.1
+      volumeMounts:
+        - mountPath: "/loki-store"
+          name: loki-store
+        - mountPath: "/etc/loki"
+          name: loki-config
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: loki
+  namespace: network-observability
+spec:
+  selector:
+    app: loki
+  ports:
+    - port: 3100
+      protocol: TCP

--- a/scripts/netobserv-metrics.yaml
+++ b/scripts/netobserv-metrics.yaml
@@ -1,0 +1,21 @@
+
+- query: pod:container_cpu_usage:sum{namespace="network-observability"}
+  metricName: cpuUsage
+
+- query: sum(container_memory_working_set_bytes{namespace="network-observability",container="",}) by (container, pod, namespace, node )
+  metricName: memoryUsage
+
+- query: avg_over_time(kubelet_volume_stats_used_bytes{namespace="network-observability", persistentvolumeclaim="loki-store"}[5m])
+  metricName: lokiStorageUsage
+
+- query: sum(rate(flow_process_nf_count[1m])*60) by (pod)
+  metricName: nFlowsProcessedPerMinute
+
+- query: flow_summary_processing_time_us{quantile="0.9"}
+  metricName: FlowProcessingTime
+
+- query: sum(rate(flow_traffic_summary_size_bytes_sum[1m])*60) by (pod)
+  metricName: nBytes
+
+- query: sum(rate(ingest_collector_flow_logs_processed[1m])*60 by (pod)
+  metricName: nFlowLogsProcessed

--- a/scripts/netobserv-metrics.yaml
+++ b/scripts/netobserv-metrics.yaml
@@ -1,21 +1,28 @@
 
+# 1. network-observability pods CPU usage
 - query: pod:container_cpu_usage:sum{namespace="network-observability"}
   metricName: cpuUsage
 
+# 2. network-observability pods memory usage
 - query: sum(container_memory_working_set_bytes{namespace="network-observability",container="",}) by (container, pod, namespace, node )
   metricName: memoryUsage
 
+# 3. loki-store PVC usage averaging over 5 mins period
 - query: avg_over_time(kubelet_volume_stats_used_bytes{namespace="network-observability", persistentvolumeclaim="loki-store"}[5m])
   metricName: lokiStorageUsage
 
+# 4. Number of netflows processed per minute aggregated by FLP pods
 - query: sum(rate(flow_process_nf_count[1m])*60) by (pod)
   metricName: nFlowsProcessedPerMinute
 
+# 5. Flow processing time in microseconds for 90% quantile.
 - query: flow_summary_processing_time_us{quantile="0.9"}
   metricName: FlowProcessingTime
 
+# 6. Number of bytes for flows per minute aggregated by FLP pods.
 - query: sum(rate(flow_traffic_summary_size_bytes_sum[1m])*60) by (pod)
   metricName: nBytes
 
-- query: sum(rate(ingest_collector_flow_logs_processed[1m])*60 by (pod)
+# 7. Number of flows processed by ingester per minute aggregated by FLP pods.
+- query: sum(rate(ingest_collector_flow_logs_processed[1m])*60) by (pod)
   metricName: nFlowLogsProcessed

--- a/scripts/netobserv.sh
+++ b/scripts/netobserv.sh
@@ -65,3 +65,10 @@ get_ipfix_collector_ip() {
     log "$OVS_IPFIX_COLLECTOR_IP is configured for $podName"
   done
 }
+
+uninstall_operatorhub_netobserv() {
+  oc delete flowcollector/cluster
+  oc delete -f $WORKSPACE/ocp-qe-perfscale/scripts/noo-subscription.yaml
+  oc delete csv/netobserv-operator.v0.1.2 -n network-observability
+  oc delete -f $WORKSPACE/ocp-qe-perfscale/scripts/operator_group.yaml
+}

--- a/scripts/netobserv.sh
+++ b/scripts/netobserv.sh
@@ -5,7 +5,10 @@ deploy_operatorhub_noo() {
   oc apply -f $WORKSPACE/ocp-qe-perfscale/scripts/noo-subscription.yaml
   sleep 20
   oc wait --timeout=180s --for=condition=ready pod -l app=network-observability-operator -n network-observability
-
+  while :; do
+    oc get crd/flowcollectors.flows.netobserv.io && break
+    sleep 1
+  done
   envsubst <$WORKSPACE/ocp-qe-perfscale/scripts/flows_v1alpha1_flowcollector_versioned.yaml >$WORKSPACE/ocp-qe-perfscale/scripts/flows.yaml
   oc apply -f $WORKSPACE/ocp-qe-perfscale/scripts/flows.yaml
   echo "====> Waiting for flowlogs-pipeline pod to be ready"

--- a/scripts/noo-subscription.yaml
+++ b/scripts/noo-subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: netobserv-operator
+  namespace: network-observability
+spec:
+  channel: alpha
+  name: netobserv-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace 

--- a/scripts/operator_group.yaml
+++ b/scripts/operator_group.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: netobserv
+  namespace: network-observability
+spec:
+  targetNamespaces:
+  - network-observability

--- a/scripts/run_workloads.sh
+++ b/scripts/run_workloads.sh
@@ -3,7 +3,13 @@ source ../../e2e-benchmarking/utils/benchmark-operator.sh
 source ./common.sh
 source ./netobserv.sh
 
-deploy_flowcollector
+if [[ $Deploy_NetObserv == "OperatorHub" ]]; then
+    deploy_operatorhub_noo
+elif [[ $Deploy_NetObserv == "main" ]]; then
+    deploy_main_noo
+fi
+
+populate_netobserv_metrics
 
 case ${WORKLOAD_TYPE} in
 uperf)
@@ -14,7 +20,7 @@ uperf)
     ;;
 node-density-heavy)
     export KUBE_BURNER_DIR='../../e2e-benchmarking/workloads/kube-burner'
-    #TODO: update
+    prep_kubeburner_workload
     export WORKLOAD="node-density-heavy"
     cd $KUBE_BURNER_DIR && ./run.sh && cd -
     ;;

--- a/scripts/service-monitor.yaml
+++ b/scripts/service-monitor.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: flowlogs-pipeline
+  name: flowlogs-pipeline
+  namespace: network-observability
+spec:
+  ports:
+  - port: 9090
+    protocol: TCP
+    targetPort: 9090
+    name: metrics
+  selector:
+    app: flowlogs-pipeline
+  type: ClusterIP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: flowlogs-pipeline
+  namespace: network-observability
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - network-observability
+  selector:
+    matchLabels:
+      app: flowlogs-pipeline
+


### PR DESCRIPTION
https://issues.redhat.com/browse/NETOBSERV-332
* Adding manifests for ServiceMonitor and ConfigMap  to send NO metrics to cluster prometheus 
* updating scripts to apply ServiceMonitor and ConfigMap manifests 
* Adding NO metrics file for kube-burner workload * updating Jenkinsfile to have python 3.9.12
* thanos URL and user workload secrets instead of prometheus for user workload metrics.
*  Create operator group
* Ability to deploy NOO from OperatorHub or from main branch

Note that: For this to work successfully, it is dependent on to get the correct token that's done by changes added to [forked e2e-benchmarking repo](https://github.com/memodi/e2e-benchmarking/blob/netobserv-trials/workloads/kube-burner/common.sh#L15-L20)

Test run from jenkins: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/memodi-e2e-benchmarking-multibranch-pipeline/job/NETOBSERV-332/21/