### PR TITLE
Fix Azure and GCP INFRA WORKLOAD configuration related issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,6 +33,7 @@ pipeline {
         string(name:'INFRA_NODES', defaultValue:'true', description:'If set to true, infra nodes machineset will be created, and options listed below will be used')
         text(name: 'ENV_VARS', defaultValue: '''PLEASE FILL ME''', description:'''<p>
                Enter list of additional Env Vars you need to pass to the script, one pair on each line. <br>
+               For OPENSHIFT_PROMETHEUS_STORAGE_CLASS and OPENSHIFT_ALERTMANAGER_STORAGE_CLASS, use `oc get storageclass` to get them on your cluster.<br>
                e.g.<b>for AWS:</b><br>
                OPENSHIFT_INFRA_NODE_VOLUME_IOPS=0            <br>
                OPENSHIFT_INFRA_NODE_VOLUME_TYPE=gp2          <br>
@@ -51,8 +52,8 @@ pipeline {
                OPENSHIFT_WORKLOAD_NODE_VOLUME_SIZE=500             <br>
                OPENSHIFT_WORKLOAD_NODE_VOLUME_TYPE=Premium_LRS     <br>
                OPENSHIFT_WORKLOAD_NODE_VM_SIZE=Standard_D32s_v3    <br>
-               OPENSHIFT_PROMETHEUS_STORAGE_CLASS=Premium_LRS  <br>
-               OPENSHIFT_ALERTMANAGER_STORAGE_CLASS=Premium_LRS<br>
+               OPENSHIFT_PROMETHEUS_STORAGE_CLASS=managed-csi  <br>
+               OPENSHIFT_ALERTMANAGER_STORAGE_CLASS=managed-csi<br>
                e.g.<b>for GCP:</b><br>
                OPENSHIFT_INFRA_NODE_VOLUME_SIZE=100    <br>
                OPENSHIFT_INFRA_NODE_VOLUME_TYPE=pd-ssd <br>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A job that will allow adding and removing firewall ports for HostNetwork Uperf t
 
 ## Current supported cloud cluster types
 * AWS
-* Azure
+* Azure (only support cluster on region: centralus)
 * GCP
 * Vsphere
 * Alicloud/Alibaba (only infra nodes)

--- a/infra-node-machineset-alicloud.yaml
+++ b/infra-node-machineset-alicloud.yaml
@@ -9,7 +9,7 @@ items:
       machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
       machine.openshift.io/cluster-api-machine-role: infra
       machine.openshift.io/cluster-api-machine-type: infra
-    name: infra-${CLUSTER_REGION}-a
+    name: ${CLUSTER_NAME}-infra-${CLUSTER_REGION}-a
     namespace: openshift-machine-api
   spec:
     replicas: 1
@@ -87,7 +87,7 @@ items:
       machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
       machine.openshift.io/cluster-api-machine-role: infra
       machine.openshift.io/cluster-api-machine-type: infra
-    name: infra-${CLUSTER_REGION}-b
+    name: ${CLUSTER_NAME}-infra-${CLUSTER_REGION}-b
     namespace: openshift-machine-api
   spec:
     replicas: 2

--- a/infra-node-machineset-aws.yaml
+++ b/infra-node-machineset-aws.yaml
@@ -8,7 +8,7 @@ items:
       ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-cluster: ${CLUSTER_NAME}
       ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-role: infra
       ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-type: infra
-    name: infra-${CLUSTER_REGION}a
+    name: ${CLUSTER_NAME}-infra-${CLUSTER_REGION}a
     namespace: openshift-machine-api
   spec:
     replicas: 1
@@ -77,7 +77,7 @@ items:
       ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-cluster: ${CLUSTER_NAME}
       ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-role: infra
       ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-type: infra
-    name: infra-${CLUSTER_REGION}b
+    name: ${CLUSTER_NAME}-infra-${CLUSTER_REGION}b
     namespace: openshift-machine-api
   spec:
     replicas: 1
@@ -146,7 +146,7 @@ items:
       ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-cluster: ${CLUSTER_NAME}
       ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-role: infra
       ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-type: infra
-    name: infra-${CLUSTER_REGION}c
+    name: ${CLUSTER_NAME}-infra-${CLUSTER_REGION}c
     namespace: openshift-machine-api
   spec:
     replicas: 1

--- a/infra-node-machineset-azure.yaml
+++ b/infra-node-machineset-azure.yaml
@@ -8,7 +8,7 @@ items:
       ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-cluster: ${CLUSTER_NAME}
       ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-role: infra
       ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-type: infra
-    name: infra-${CLUSTER_NAME}1
+    name: ${CLUSTER_NAME}-infra-${AZURE_LOCATION}1
     namespace: openshift-machine-api
   spec:
     replicas: 1
@@ -43,7 +43,7 @@ items:
               version: ""
             internalLoadBalancer: ""
             kind: AzureMachineProviderSpec
-            location: centralus
+            location: ${AZURE_LOCATION}
             managedIdentity: ${CLUSTER_NAME}-identity
             metadata:
               creationTimestamp: null
@@ -75,7 +75,7 @@ items:
       ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-cluster: ${CLUSTER_NAME}
       ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-role: infra
       ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-type: infra
-    name: infra-${AZURE_LOCATION}2
+    name: ${CLUSTER_NAME}-infra-${AZURE_LOCATION}2
     namespace: openshift-machine-api
   spec:
     replicas: 1
@@ -110,7 +110,7 @@ items:
               version: ""
             internalLoadBalancer: ""
             kind: AzureMachineProviderSpec
-            location: centralus
+            location: ${AZURE_LOCATION}
             managedIdentity: ${CLUSTER_NAME}-identity
             metadata:
               creationTimestamp: null
@@ -142,7 +142,7 @@ items:
       ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-cluster: ${CLUSTER_NAME}
       ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-role: infra
       ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-type: infra
-    name: infra-${AZURE_LOCATION}3
+    name: ${CLUSTER_NAME}-infra-${AZURE_LOCATION}3
     namespace: openshift-machine-api
   spec:
     replicas: 1
@@ -177,7 +177,7 @@ items:
               version: ""
             internalLoadBalancer: ""
             kind: AzureMachineProviderSpec
-            location: centralus
+            location: ${AZURE_LOCATION}
             managedIdentity: ${CLUSTER_NAME}-identity
             metadata:
               creationTimestamp: null

--- a/infra-node-machineset-gcp.yaml
+++ b/infra-node-machineset-gcp.yaml
@@ -6,7 +6,9 @@ items:
     generation: 1
     labels:
       ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-cluster: ${CLUSTER_NAME}
-    name: infra-${CLUSTER_NAME}a
+      ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-role: infra
+      ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-type: infra
+    name: ${CLUSTER_NAME}-infra-${CLUSTER_NAME}a
     namespace: openshift-machine-api
   spec:
     replicas: 1
@@ -69,7 +71,9 @@ items:
     generation: 1
     labels:
       ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-cluster: ${CLUSTER_NAME}
-    name: infra-${CLUSTER_NAME}b
+      ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-role: infra
+      ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-type: infra
+    name: ${CLUSTER_NAME}-infra-${CLUSTER_NAME}b
     namespace: openshift-machine-api
   spec:
     replicas: 1
@@ -132,7 +136,9 @@ items:
     generation: 1
     labels:
       ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-cluster: ${CLUSTER_NAME}
-    name: infra-${CLUSTER_NAME}c
+      ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-role: infra
+      ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-type: infra
+    name: ${CLUSTER_NAME}-infra-${CLUSTER_NAME}c
     namespace: openshift-machine-api
   spec:
     replicas: 1

--- a/infra-node-machineset-ibmcloud.yaml
+++ b/infra-node-machineset-ibmcloud.yaml
@@ -9,7 +9,7 @@ items:
       machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
       machine.openshift.io/cluster-api-machine-role: infra
       machine.openshift.io/cluster-api-machine-type: infra
-    name: ${CLUSTER_NAME}-infra-1
+    name: ${CLUSTER_NAME}-infra-${CLUSTER_REGION}-1
     namespace: openshift-machine-api
   spec:
     replicas: 1
@@ -57,7 +57,7 @@ items:
       machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
       machine.openshift.io/cluster-api-machine-role: infra
       machine.openshift.io/cluster-api-machine-type: infra
-    name: ${CLUSTER_NAME}-infra-2
+    name: ${CLUSTER_NAME}-infra-${CLUSTER_REGION}-2
     namespace: openshift-machine-api
   spec:
     replicas: 1
@@ -105,7 +105,7 @@ items:
       machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
       machine.openshift.io/cluster-api-machine-role: infra
       machine.openshift.io/cluster-api-machine-type: infra
-    name: '${CLUSTER_NAME}-infra-3'
+    name: ${CLUSTER_NAME}-infra-${CLUSTER_REGION}-3
     namespace: openshift-machine-api
   spec:
     replicas: 1

--- a/infra-node-machineset-vsphere.yaml
+++ b/infra-node-machineset-vsphere.yaml
@@ -4,7 +4,7 @@ metadata:
   generation: 1
   labels:
     ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-cluster: ${CLUSTER_NAME}
-  name: infra-machines-${CLUSTER_NAME}
+  name: ${CLUSTER_NAME}-infra-machines-${CLUSTER_NAME}
   namespace: openshift-machine-api
 spec:
   replicas: 3

--- a/workload-node-machineset-alicloud.yaml
+++ b/workload-node-machineset-alicloud.yaml
@@ -5,7 +5,7 @@ metadata:
     machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
     machine.openshift.io/cluster-api-machine-role: workload
     machine.openshift.io/cluster-api-machine-type: workload
-  name: workload-${CLUSTER_REGION}-a
+  name:${CLUSTER_NAME}- workload-${CLUSTER_REGION}-a
   namespace: openshift-machine-api
 spec:
   replicas: 1

--- a/workload-node-machineset-aws.yaml
+++ b/workload-node-machineset-aws.yaml
@@ -6,7 +6,7 @@ metadata:
     ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-cluster: ${CLUSTER_NAME}
     ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-role: workload
     ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-type: workload
-  name: workload-${CLUSTER_REGION}a
+  name: ${CLUSTER_NAME}-workload-${CLUSTER_REGION}a
   namespace: openshift-machine-api
 spec:
   replicas: 1

--- a/workload-node-machineset-azure.yaml
+++ b/workload-node-machineset-azure.yaml
@@ -6,7 +6,7 @@ metadata:
     ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-cluster: ${CLUSTER_NAME}
     ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-role: workload
     ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-type: workload
-  name: workload-${CLUSTER_NAME}
+  name: ${CLUSTER_NAME}-workload-${AZURE_LOCATION}
   namespace: openshift-machine-api
 spec:
   replicas: 1
@@ -41,7 +41,7 @@ spec:
             version: ""
           internalLoadBalancer: ""
           kind: AzureMachineProviderSpec
-          location: centralus
+          location: ${AZURE_LOCATION}
           managedIdentity: ${CLUSTER_NAME}-identity
           metadata:
             creationTimestamp: null

--- a/workload-node-machineset-gcp.yaml
+++ b/workload-node-machineset-gcp.yaml
@@ -4,7 +4,9 @@ metadata:
   generation: 1
   labels:
     ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-cluster: ${CLUSTER_NAME}
-  name: workload-${CLUSTER_NAME}
+    ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-role: workload
+    ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-machine-type: workload
+  name: ${CLUSTER_NAME}-workload-${CLUSTER_NAME}
   namespace: openshift-machine-api
 spec:
   replicas: 1

--- a/workload-node-machineset-vsphere.yaml
+++ b/workload-node-machineset-vsphere.yaml
@@ -4,7 +4,7 @@ metadata:
   generation: 1
   labels:
     ${MACHINESET_METADATA_LABEL_PREFIX}/cluster-api-cluster: ${CLUSTER_NAME}
-  name: workload-machines-${CLUSTER_NAME}
+  name: ${CLUSTER_NAME}-workload-machines-${CLUSTER_NAME}
   namespace: openshift-machine-api
 spec:
   replicas: 1


### PR DESCRIPTION
Fix https://github.com/openshift-qe/ocp-qe-perfscale-ci/issues/148 and https://github.com/openshift-qe/ocp-qe-perfscale-ci/issues/153
Summary of changes:
1. Fix hard code of location on azure
2. Update the storage class of Azure to the default storageclass `managed-csi`
3. Add comment to README that Azure only support `region: centralus`
4. Add cluster name to machiesets name as prefix for all providers, this will help to identify owner of resources.
5. add infra and workload label to metadata of GCP machinesets https://github.com/openshift-qe/ocp-qe-perfscale-ci/issues/153