### PR TITLE
Main branch and repo url for cerberus

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,8 +36,8 @@ pipeline {
                SOMEVARn='envn-test'<br>
                </p>'''
             )
-       string(name: 'CERBERUS_REPO', defaultValue:'https://github.com/cloud-bulldozer/cerberus', description:'You can change this to point to your fork if needed.')
-       string(name: 'CERBERUS_REPO_BRANCH', defaultValue:'master', description:'You can change this to point to a branch on your fork if needed.')
+       string(name: 'CERBERUS_REPO', defaultValue:'https://github.com/chaos-kubox/cerberus', description:'You can change this to point to your fork if needed.')
+       string(name: 'CERBERUS_REPO_BRANCH', defaultValue:'main', description:'You can change this to point to a branch on your fork if needed.')
      }
 
   stages {


### PR DESCRIPTION
Forgot that we changed the name of the repository cerberus is in and switch master to main. Had git pulling issues with old branch/url on jenkins