### PR TITLE
To scale up and down the clusters by changing machinesets replicas count for worker nodes on ibmcloud

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -209,6 +209,21 @@ OPENSHIFT_PROMETHEUS_RETENTION_PERIOD=15d
 OPENSHIFT_PROMETHEUS_STORAGE_SIZE=500Gi
 OPENSHIFT_ALERTMANAGER_STORAGE_SIZE=20Gi
               ''')]
+            } else if(env.VARIABLES_LOCATION.indexOf("ibmcloud") != -1){
+              build job: 'scale-ci/e2e-benchmarking-multibranch-pipeline/cluster-post-config', parameters: [
+              string(name: 'BUILD_NUMBER', value: BUILD_NUMBER), string(name: 'HOST_NETWORK_CONFIGS', value:'false'),
+              string(name: 'PROVISION_OR_TEARDOWN', value: 'PROVISION'),
+              string(name: 'JENKINS_AGENT_LABEL', value: JENKINS_AGENT_LABEL),
+              string(name: 'INFRA_NODES', value: 'true'),
+              text(name: 'ENV_VARS', value: ENV_VARS + '''
+OPENSHIFT_INFRA_NODE_INSTANCE_TYPE=bx2d-48x192
+OPENSHIFT_WORKLOAD_NODE_INSTANCE_TYPE=bx2-32x128
+OPENSHIFT_PROMETHEUS_STORAGE_CLASS=ibmc-vpc-block-5iops-tier
+OPENSHIFT_ALERTMANAGER_STORAGE_CLASS=ibmc-vpc-block-5iops-tier
+OPENSHIFT_PROMETHEUS_RETENTION_PERIOD=15d
+OPENSHIFT_PROMETHEUS_STORAGE_SIZE=500Gi
+OPENSHIFT_ALERTMANAGER_STORAGE_SIZE=20Gi
+              ''')]
             } else {
             echo "Cloud type is not set up yet"
             }


### PR DESCRIPTION

Currently infra scale up for ibmcloud provider is not setup in

https://issues.redhat.com/browse/OCPQE-10249

https://github.com/openshift-qe/ocp-qe-perfscale-ci/blob/cluster-workers-scaling/
add if statement for ibmcloud in https://github.com/openshift-qe/ocp-qe-perfscale-ci/tree/cluster-workers-scaling

to pass the parameters listed here
https://github.com/openshift-qe/ocp-qe-perfscale-ci/blob/d7cfdac2e05dbd98f894a14cc048580f0b2a4b01/Jenkinsfile#L84

Case1:  check the INFRA_WORKLOAD_INSTALL with workers=40; cluster-post-config should be triggered; test success ; https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/sninganu-e2e-benchmarking-multibranch-pipeline/job/cluster-workers-scaling/17/console


Case2:  uncheck the INFRA_WORKLOAD_INSTALL with workers=3;cluster-post-config should not be triggered; test success https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/sninganu-e2e-benchmarking-multibranch-pipeline/job/cluster-workers-scaling/18/


Case3:  check the INFRA_WORKLOAD_INSTALL with workers=10;cluster-post-config should be triggered; test success ;https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/sninganu-e2e-benchmarking-multibranch-pipeline/job/cluster-workers-scaling/19/console
