### PR TITLE
Adding osp with templates for infra and workload nodes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,6 +86,9 @@ pipeline {
                OPENSHIFT_WORKLOAD_NODE_INSTANCE_TYPE=bx2-32x128<br>
                OPENSHIFT_PROMETHEUS_STORAGE_CLASS=ibmc-vpc-block-5iops-tier<br>
                OPENSHIFT_ALERTMANAGER_STORAGE_CLASS=ibmc-vpc-block-5iops-tier<br>
+               e.g. <b>for OSP:</b><br>
+               OPENSHIFT_INFRA_NODE_INSTANCE_TYPE=ci.cpu.xxxl<br>
+               OPENSHIFT_WORKLOAD_NODE_INSTANCE_TYPE=ci.cpu.xxl<br>
                <b>And ALWAYS INCLUDE(except for vSphere provider) this part, for Prometheus AlertManager, it may look like</b>:<br>
                OPENSHIFT_PROMETHEUS_RETENTION_PERIOD=15d<br>
                OPENSHIFT_PROMETHEUS_STORAGE_SIZE=500Gi  <br>
@@ -347,6 +350,9 @@ pipeline {
               export CLUSTER_REGION=$(oc get machineset -n openshift-machine-api -o=go-template='{{(index .items 0).spec.template.spec.providerSpec.value.region}}')
               envsubst < infra-node-machineset-ibmcloud.yaml | oc apply -f -
               envsubst < workload-node-machineset-ibmcloud.yaml | oc apply -f -
+            elif [[ $(echo $VARIABLES_LOCATION | grep osp -c) > 0 ]]; then
+              envsubst < infra-node-machineset-osp.yaml | oc apply -f -
+              envsubst < workload-node-machineset-osp.yaml | oc apply -f -
             fi
             retries=0
             attempts=60

--- a/infra-node-machineset-osp.yaml
+++ b/infra-node-machineset-osp.yaml
@@ -1,0 +1,53 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+    machine.openshift.io/cluster-api-machine-role: infra
+    machine.openshift.io/cluster-api-machine-type: infra
+  name: ${CLUSTER_NAME}-infra
+  namespace: openshift-machine-api
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+      machine.openshift.io/cluster-api-machineset: ${CLUSTER_NAME}-infra
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+        machine.openshift.io/cluster-api-machine-role: infra
+        machine.openshift.io/cluster-api-machine-type: infra
+        machine.openshift.io/cluster-api-machineset: ${CLUSTER_NAME}-infra
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/infra: ""
+      providerSpec:
+        value:
+          apiVersion: openstackproviderconfig.openshift.io/v1alpha1
+          cloudName: openstack
+          cloudsSecret:
+            name: openstack-cloud-credentials
+            namespace: openshift-machine-api
+          flavor: ${OPENSHIFT_INFRA_NODE_INSTANCE_TYPE}
+          image: ${CLUSTER_NAME}-rhcos
+          kind: OpenstackProviderSpec
+          networks:
+          - filter: {}
+            subnets:
+            - filter:
+                name: ${CLUSTER_NAME}-nodes
+                tags: openshiftClusterID=${CLUSTER_NAME}
+          securityGroups:
+          - filter: {}
+            name: ${CLUSTER_NAME}-worker
+          serverMetadata:
+            Name: ${CLUSTER_NAME}-worker
+            openshiftClusterID: ${CLUSTER_NAME}
+          tags:
+          - openshiftClusterID=${CLUSTER_NAME}
+          trunk: true
+          userDataSecret:
+            name: worker-user-data

--- a/workload-node-machineset-osp.yaml
+++ b/workload-node-machineset-osp.yaml
@@ -1,0 +1,53 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+    machine.openshift.io/cluster-api-machine-role: workload
+    machine.openshift.io/cluster-api-machine-type: workload
+  name: ${CLUSTER_NAME}-workload
+  namespace: openshift-machine-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+      machine.openshift.io/cluster-api-machineset: ${CLUSTER_NAME}-workload
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: ${CLUSTER_NAME}
+        machine.openshift.io/cluster-api-machine-role: workload
+        machine.openshift.io/cluster-api-machine-type: workload
+        machine.openshift.io/cluster-api-machineset: ${CLUSTER_NAME}-workload
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/workload: ""
+      providerSpec:
+        value:
+          apiVersion: openstackproviderconfig.openshift.io/v1alpha1
+          cloudName: openstack
+          cloudsSecret:
+            name: openstack-cloud-credentials
+            namespace: openshift-machine-api
+          flavor: ${OPENSHIFT_WORKLOAD_NODE_INSTANCE_TYPE}
+          image: ${CLUSTER_NAME}-rhcos
+          kind: OpenstackProviderSpec
+          networks:
+          - filter: {}
+            subnets:
+            - filter:
+                name: ${CLUSTER_NAME}-nodes
+                tags: openshiftClusterID=${CLUSTER_NAME}
+          securityGroups:
+          - filter: {}
+            name: ${CLUSTER_NAME}-worker
+          serverMetadata:
+            Name: ${CLUSTER_NAME}-worker
+            openshiftClusterID: ${CLUSTER_NAME}
+          tags:
+          - openshiftClusterID=${CLUSTER_NAME}
+          trunk: true
+          userDataSecret:
+            name: worker-user-data


### PR DESCRIPTION
Adding in infra and workload node templates for OSP 

This incorporates the changes that were in https://github.com/openshift-qe/ocp-qe-perfscale-ci/pull/163 into this one so I was able to fully test this addition

https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/paige-e2e-multibranch/job/cluster-post-config/69/console