### PR TITLE
Setting correct status for kube burner job 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -153,6 +153,11 @@ pipeline {
                     ./run.sh | tee "kube-burner.out"
                 ''')
               output = sh(returnStdout: true, script: 'cat workloads/kube-burner/kube-burner.out')
+              if (RETURNSTATUS.toInteger() == 0) {
+                  status = "PASS"
+              } else { 
+                  currentBuild.result = "FAILURE"
+              }
           }
         }
 


### PR DESCRIPTION
Adding setting of correct pass status based on result of run.sh 

https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/paige-e2e-multibranch/job/kube-burner/53/console