### PR TITLE
Only check the CoreOS worker

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,7 +87,7 @@ pipeline {
                       set +x
                       local retries=0
                       local attempts=100
-                      while [[ $(oc get nodes --no-headers -l node-role.kubernetes.io/worker | grep -v "NotReady\\|SchedulingDisabled" | grep worker -c) != $1 ]]; do
+                      while [[ $(oc get nodes --no-headers -l node-role.kubernetes.io/worker -o wide | grep CoreOS | grep -v "NotReady\\|SchedulingDisabled" | grep worker -c) != $1 ]]; do
                           log "Following nodes are currently present, waiting for desired count $1 to be met."
                           log "Machinesets:"
                           oc get machinesets -A


### PR DESCRIPTION
On a hybrid cluster, I scaled CoreOS machineset to 38 workers, but the code get 75 workers because I have 37 RHEL workers installed on the cluster.
The code compare 38(expected) and 75, it doesn't match, so the loop will continue to check until max attempt is reached.
```
% oc get nodes --no-headers -l node-role.kubernetes.io/worker | grep -v "NotReady\\|SchedulingDisabled" | grep worker -c
75
% oc get nodes --no-headers -l node-role.kubernetes.io/worker -o wide| grep CoreOS | grep -v "NotReady\\|SchedulingDisabled" | grep worker -c
38
```
