### PR TITLE
Adding cerberus fix for inspect data folder

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,7 @@ if (userId) {
 
 def RETURNSTATUS = "default"
 def output = ""
+def status = "FAIL"
 pipeline {
   agent none
   parameters {
@@ -93,10 +94,7 @@ pipeline {
           exit $final_health
 
           ''')
-          sh "echo $RETURNSTATUS"
-        }
-      script{
-            def status = "FAIL"
+            
             sh "echo $RETURNSTATUS"
             if( RETURNSTATUS.toString() == "0") {
                 status = "PASS"
@@ -105,7 +103,7 @@ pipeline {
            }
       }
       script {
-          if (fileExists("inspect_data")) {
+          if (status != "PASS" && fileExists("inspect_data")) {
              archiveArtifacts artifacts: 'inspect_data/*,inspect_data/**', fingerprint: false
           }
        }


### PR DESCRIPTION
Was getting error seen below if the checks passed, fixing to check if cerberus passes first 

https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/cerberus/98/console
```
07-12 10:21:05.794  Archiving artifacts
07-12 10:21:05.831  ‘inspect_data/*’ doesn’t match anything, but ‘*’ does. Perhaps that’s what you mean?
07-12 10:21:05.836  [Pipeline] }
07-12 10:21:05.840  [Pipeline] // script
07-12 10:21:05.843  [Pipeline] }
07-12 10:21:05.846  [Pipeline] // withEnv
07-12 10:21:05.886  [Pipeline] }
07-12 10:21:05.894  [Pipeline] // node
07-12 10:21:05.897  [Pipeline] }
07-12 10:21:05.900  [Pipeline] // stage
07-12 10:21:05.904  [Pipeline] End of Pipeline
07-12 10:21:05.914  ERROR: No artifacts found that match the file pattern "inspect_data/*,inspect_data/**". Configuration error?
07-12 10:21:05.926  Finished: FAILURE
```



Working job: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/paige-e2e-multibranch/job/cerberus/199/console