### PR TITLE
add env vars for cluser needs proxy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,6 +130,8 @@ pipeline {
   
                 oc whoami''')
               def architecture_type = sh(returnStdout: true, script: '''
+                # Export those env vars so they could be used by CI Job
+                set -a && source .env_override && set +a
                 node_name=$(oc get node --no-headers | grep master| head -1| awk '{print $1}')
                 oc get node $node_name -ojsonpath='{.status.nodeInfo.architecture}'
               ''')


### PR DESCRIPTION
The last change of getting architecture_type didn't pass env vars so it failed for cluster needs proxy.
Failed job https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/cluster-workers-scaling/1090/console
```
07-19 13:34:05.287  [Pipeline] }
07-19 13:34:05.291  [Pipeline] // script
07-19 13:34:05.295  [Pipeline] script
07-19 13:34:05.296  [Pipeline] {
07-19 13:34:05.300  [Pipeline] sh
07-19 13:34:05.570  + mkdir -p /home/jenkins/.kube
07-19 13:34:05.571  + echo 'http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@20.9.34.150:3128/
07-19 13:34:05.571  https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@20.9.34.150:3128/'
07-19 13:34:05.571  + set -a
07-19 13:34:05.571  + source .env_override
07-19 13:34:05.571  ++ http_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@20.9.34.150:3128/
07-19 13:34:05.571  ++ https_proxy=http://proxy-user1:JYgU8qRZV4DY4PXJbxJK@20.9.34.150:3128/
07-19 13:34:05.571  + set +a
07-19 13:34:05.571  + cp /home/jenkins/ws/workspace/pipeline_cluster-workers-scaling/flexy-artifacts/workdir/install-dir/auth/kubeconfig /home/jenkins/.kube/config
07-19 13:34:05.571  + oc cluster-info
07-19 13:34:05.826  [0;32mKubernetes control plane[0m is running at [0;33mhttps://api.qili-az-p0719.qe.azure.devcluster.openshift.com:6443[0m
07-19 13:34:05.826  
07-19 13:34:05.826  To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
07-19 13:34:05.826  + oc whoami
07-19 13:34:06.081  system:admin
07-19 13:34:06.088  [Pipeline] sh
07-19 13:34:06.356  ++ oc get node --no-headers
07-19 13:34:06.357  ++ grep master
07-19 13:34:06.357  ++ head -1
07-19 13:34:06.357  ++ awk '{print $1}'
07-19 13:34:06.357  Unable to connect to the server: dial tcp: lookup api.qili-az-p0719.qe.azure.devcluster.openshift.com on 172.27.0.10:53: no such host
07-19 13:34:06.357  + node_name=
07-19 13:34:06.357  + oc get node '-ojsonpath={.status.nodeInfo.architecture}'
07-19 13:34:06.612  Unable to connect to the server: dial tcp: lookup api.qili-az-p0719.qe.azure.devcluster.openshift.com on 172.27.0.10:53: no such host
```

Passed Job
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/qili-e2e-benchmark/job/cluster-workers-scaling/6/console