### PR TITLE
Azure private infra and workload machineset yaml fix image pull failure from quay

### DIFF
--- a/infra-node-machineset-azure-customervpc.yaml
+++ b/infra-node-machineset-azure-customervpc.yaml
@@ -31,7 +31,8 @@ items:
             node-role.kubernetes.io/infra: ""
         providerSpec:
           value:
-            apiVersion: azureproviderconfig.openshift.io/v1beta1
+            acceleratedNetworking: true
+            apiVersion: machine.openshift.io/v1beta1
             credentialsSecret:
               name: azure-cloud-credentials
               namespace: openshift-machine-api
@@ -96,7 +97,8 @@ items:
             node-role.kubernetes.io/infra: ""
         providerSpec:
           value:
-            apiVersion: azureproviderconfig.openshift.io/v1beta1
+            acceleratedNetworking: true
+            apiVersion: machine.openshift.io/v1beta1
             credentialsSecret:
               name: azure-cloud-credentials
               namespace: openshift-machine-api
@@ -120,7 +122,7 @@ items:
                 storageAccountType: ${OPENSHIFT_INFRA_NODE_VOLUME_TYPE}
               osType: Linux
             publicIP: false
-            publicLoadBalancer: ""
+            publicLoadBalancer: ${CLUSTER_NAME}
             resourceGroup: ${CLUSTER_NAME}-rg
             sshPrivateKey: ""
             sshPublicKey: ""
@@ -161,7 +163,8 @@ items:
             node-role.kubernetes.io/infra: ""
         providerSpec:
           value:
-            apiVersion: azureproviderconfig.openshift.io/v1beta1
+            acceleratedNetworking: true
+            apiVersion: machine.openshift.io/v1beta1
             credentialsSecret:
               name: azure-cloud-credentials
               namespace: openshift-machine-api
@@ -185,7 +188,7 @@ items:
                 storageAccountType: ${OPENSHIFT_INFRA_NODE_VOLUME_TYPE}
               osType: Linux
             publicIP: false
-            publicLoadBalancer: ""
+            publicLoadBalancer: ${CLUSTER_NAME}
             resourceGroup: ${CLUSTER_NAME}-rg
             sshPrivateKey: ""
             sshPublicKey: ""

--- a/workload-node-machineset-azure-customervpc.yaml
+++ b/workload-node-machineset-azure-customervpc.yaml
@@ -29,7 +29,8 @@ spec:
           node-role.kubernetes.io/workload: ""
       providerSpec:
         value:
-          apiVersion: azureproviderconfig.openshift.io/v1beta1
+          acceleratedNetworking: true
+          apiVersion: machine.openshift.io/v1beta1
           credentialsSecret:
             name: azure-cloud-credentials
             namespace: openshift-machine-api


### PR DESCRIPTION
Still have image pull failure from quay, I did some additional fix.

Record a worker machineset yaml for reference:
```
# oc get machineset qili-az-p0720-pgpsp-worker-centralus1 -n openshift-machine-api -o yaml
apiVersion: machine.openshift.io/v1beta1
kind: MachineSet
metadata:
  annotations:
    machine.openshift.io/GPU: "0"
    machine.openshift.io/memoryMb: "32768"
    machine.openshift.io/vCPU: "8"
  creationTimestamp: "2022-07-20T01:33:22Z"
  generation: 2
  labels:
    machine.openshift.io/cluster-api-cluster: qili-az-p0720-pgpsp
    machine.openshift.io/cluster-api-machine-role: worker
    machine.openshift.io/cluster-api-machine-type: worker
  name: qili-az-p0720-pgpsp-worker-centralus1
  namespace: openshift-machine-api
  resourceVersion: "275948"
  uid: a927012f-5623-4f0f-929c-3d74d4bed338
spec:
  replicas: 25
  selector:
    matchLabels:
      machine.openshift.io/cluster-api-cluster: qili-az-p0720-pgpsp
      machine.openshift.io/cluster-api-machineset: qili-az-p0720-pgpsp-worker-centralus1
  template:
    metadata:
      labels:
        machine.openshift.io/cluster-api-cluster: qili-az-p0720-pgpsp
        machine.openshift.io/cluster-api-machine-role: worker
        machine.openshift.io/cluster-api-machine-type: worker
        machine.openshift.io/cluster-api-machineset: qili-az-p0720-pgpsp-worker-centralus1
    spec:
      lifecycleHooks: {}
      metadata: {}
      providerSpec:
        value:
          acceleratedNetworking: true
          apiVersion: machine.openshift.io/v1beta1
          credentialsSecret:
            name: azure-cloud-credentials
            namespace: openshift-machine-api
          image:
            offer: ""
            publisher: ""
            resourceID: /resourceGroups/qili-az-p0720-pgpsp-rg/providers/Microsoft.Compute/images/qili-az-p0720-pgpsp-gen2
            sku: ""
            version: ""
          kind: AzureMachineProviderSpec
          location: centralus
          managedIdentity: qili-az-p0720-pgpsp-identity
          metadata:
            creationTimestamp: null
          networkResourceGroup: qili-az-p0720-rg
          osDisk:
            diskSettings: {}
            diskSizeGB: 128
            managedDisk:
              storageAccountType: Premium_LRS
            osType: Linux
          publicIP: false
          publicLoadBalancer: qili-az-p0720-pgpsp
          resourceGroup: qili-az-p0720-pgpsp-rg
          subnet: qili-az-p0720-worker-subnet
          userDataSecret:
            name: worker-user-data
          vmSize: Standard_D8s_v3
          vnet: qili-az-p0720-vnet
          zone: "1"
status:
  availableReplicas: 25
  fullyLabeledReplicas: 25
  observedGeneration: 2
  readyReplicas: 25
  replicas: 25
```

Tested with Job: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/qili-e2e-benchmark/job/cluster-post-config/36/console

Verification of infra/workload machinesets and ingress/monitoring pods:
```
# oc get machinesets -A
NAMESPACE               NAME                                    DESIRED   CURRENT   READY   AVAILABLE   AGE
openshift-machine-api   qili-az-p0720-pgpsp-infra-1             1         1                             8m27s
openshift-machine-api   qili-az-p0720-pgpsp-infra-2             1         1                             8m26s
openshift-machine-api   qili-az-p0720-pgpsp-infra-3             1         1                             8m26s
openshift-machine-api   qili-az-p0720-pgpsp-worker-centralus1   25        25        25      25          5h24m
openshift-machine-api   qili-az-p0720-pgpsp-worker-centralus2   25        25        25      25          5h24m
openshift-machine-api   qili-az-p0720-pgpsp-worker-centralus3   25        25        25      25          5h24m
openshift-machine-api   qili-az-p0720-pgpsp-workload            1         1                             8m26s
```
```
# oc get po -o wide -n openshift-monitoring | grep infra
alertmanager-main-1                                      0/6     ContainerCreating   0          17m     <none>         qili-az-p0720-pgpsp-infra-3-r4zn8             <none>           <none>
kube-state-metrics-b49849976-chdcc                       3/3     Running             0          17m     10.131.42.9    qili-az-p0720-pgpsp-infra-2-v2mrm             <none>           <none>
node-exporter-9hw25                                      2/2     Running             0          4m51s   10.0.1.80      qili-az-p0720-pgpsp-infra-1-zt8b4             <none>           <none>
node-exporter-fb8h6                                      2/2     Running             0          8m9s    10.0.1.82      qili-az-p0720-pgpsp-infra-2-v2mrm             <none>           <none>
node-exporter-hj72t                                      2/2     Running             0          44m     10.0.1.84      qili-az-p0720-pgpsp-infra-2-phms4             <none>           <none>
node-exporter-mrn9k                                      2/2     Running             0          44m     10.0.1.81      qili-az-p0720-pgpsp-infra-1-ns47t             <none>           <none>
node-exporter-x4l5f                                      2/2     Running             0          8m5s    10.0.1.83      qili-az-p0720-pgpsp-infra-3-r4zn8             <none>           <none>
prometheus-adapter-579fd498c6-22gdp                      0/1     ContainerCreating   0          12s     <none>         qili-az-p0720-pgpsp-infra-3-r4zn8             <none>           <none>
prometheus-adapter-579fd498c6-9b97h                      1/1     Running             0          17m     10.131.42.11   qili-az-p0720-pgpsp-infra-2-v2mrm             <none>           <none>
prometheus-k8s-0                                         0/6     Init:0/1            0          18m     <none>         qili-az-p0720-pgpsp-infra-3-r4zn8             <none>           <none>
prometheus-k8s-1                                         6/6     Running             0          36m     10.130.40.11   qili-az-p0720-pgpsp-infra-1-ns47t             <none>           <none>
prometheus-operator-85c6b96855-k2jzc                     2/2     Running             0          17m     10.131.42.10   qili-az-p0720-pgpsp-infra-2-v2mrm             <none>           <none>
prometheus-operator-admission-webhook-6f6f6476bb-9g9cs   0/1     ContainerCreating   0          68s     <none>         qili-az-p0720-pgpsp-infra-3-r4zn8             <none>           <none>
prometheus-operator-admission-webhook-6f6f6476bb-bmwbt   1/1     Running             0          18m     10.131.42.8    qili-az-p0720-pgpsp-infra-2-v2mrm             <none>           <none>
```
```
# oc get po -o wide -n openshift-ingress
NAME                              READY   STATUS        RESTARTS   AGE   IP            NODE                                NOMINATED NODE   READINESS GATES
router-default-84b665dc75-6pzcv   1/1     Running       0          17m   10.131.42.5   qili-az-p0720-pgpsp-infra-2-v2mrm   <none>           <none>
router-default-84b665dc75-fvbmn   0/1     Terminating   0          53m   10.130.40.5   qili-az-p0720-pgpsp-infra-1-ns47t   <none>           <none>
router-default-84b665dc75-rmtr4   1/1     Running       0          59s   10.128.44.7   qili-az-p0720-pgpsp-infra-3-r4zn8   <none>           <none>
```