### PR TITLE
minor and major version for profile folder

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -375,7 +375,11 @@ pipeline{
                         if(params.CI_PROFILE != "" ) {
 
                             // read data from CI profile install file
-                            installData = readYaml(file: "local-ci-profiles/scale-ci/4.10/${CI_PROFILE}.install.yaml")
+                            MAJOR_VERSION = params.OCP_VERSION.split("\\.")[0]
+                            MINOR_VERSION = params.OCP_VERSION.split("\\.")[1]
+
+
+                            installData = readYaml(file: "local-ci-profiles/scale-ci/$MAJOR_VERSION.$MINOR_VERSION/${CI_PROFILE}.install.yaml")
                             installData.install.flexy.each { env.setProperty(it.key, it.value) }
                             // loop through install data keys to make sure scale is one of them
                             def scale_profile_size = 0


### PR DESCRIPTION
Don't want hardcoded 4.10 folder when looking at profiles as there are different profiles now in each of the versioned folders

Job now with properly getting profile in 4.12 folder: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/paige-e2e-multibranch/job/loaded-upgrade/340/console

[failing job](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/loaded-upgrade/632/) with original issue