### PR TITLE
updates for PR # 256

### DIFF
--- a/scripts/nope.py
+++ b/scripts/nope.py
@@ -152,20 +152,20 @@ def get_netobserv_env_info():
     }
     base_commands = {
         "release": ['oc', 'get', 'pods', '-l', 'app=network-observability-operator', '-o', 'jsonpath="{.items[*].spec.containers[1].env[0].value}"', '-n', 'network-observability'],
-        "flp_kind": ['oc', 'get', 'flowcollector', '-o', 'jsonpath="{.items[*].spec.flowlogsPipeline.kind}"', '-n', 'network-observability'],
-        "agent": ['oc', 'get', 'flowcollector', '-o', 'jsonpath="{.items[*].spec.agent}"']
+        "flp_kind": ['oc', 'get', 'flowcollector', '-o', 'jsonpath="{.items[*].spec.processor.kind}"', '-n', 'network-observability'],
+        "agent": ['oc', 'get', 'flowcollector', '-o', 'jsonpath="{.items[*].spec.agent.type}"']
     }
 
     # collect data from cluster about netobserv operator and store in info dict
     info = run_commands(base_commands, info)
 
     # get agent details based on detected agent
-    agent = info["agent"]
+    agent = info["agent"].lower()
     logging.debug(f"Found collector agent {agent}")
     agent_commands = {
-        "sampling": ['oc', 'get', 'flowcollector', '-o', f'jsonpath="{{.items[*].spec.{agent}.sampling}}"'],
-        "cache_active_time": ['oc', 'get', 'flowcollector', '-o', f'jsonpath="{{.items[*].spec.{agent}.cacheActiveTimeout}}"'],
-        "cache_max_flows": ['oc', 'get', 'flowcollector', '-o', f'jsonpath="{{.items[*].spec.{agent}.cacheMaxFlows}}"']
+        "sampling": ['oc', 'get', 'flowcollector', '-o', f'jsonpath="{{.items[*].spec.agent.{agent}.sampling}}"'],
+        "cache_active_time": ['oc', 'get', 'flowcollector', '-o', f'jsonpath="{{.items[*].spec.agent.{agent}.cacheActiveTimeout}}"'],
+        "cache_max_flows": ['oc', 'get', 'flowcollector', '-o', f'jsonpath="{{.items[*].spec.agent.{agent}.cacheMaxFlows}}"']
     }
 
     # collect data from cluster about agent and append to info dict


### PR DESCRIPTION
tested nope.py locally:
```
$ python nope.py --starttime 1662738423 --endtime 1662738838 --jenkins-job scale-ci/e2e-benchmarking-multibranch-pipeline/kube-burner --jenkins-build 1227 --uuid 1dc028ad-ff3d-48fb-bb23-7876760eeb35 --user-workloads --dump
INFO:root:Parsed Start Time: 11:47AM UTC on 09/09/2022
INFO:root:Parsed End Time:   11:53AM UTC on 09/09/2022
INFO:root:Step is:           10
INFO:root:Associating run with Jenkins job scale-ci/e2e-benchmarking-multibranch-pipeline/kube-burner build number 1227
INFO:root:UUID: 1dc028ad-ff3d-48fb-bb23-7876760eeb35
INFO:root:YAML_FILE: netobserv_queries_ebpf.yaml
INFO:root:THANOS_URL: https://thanos-querier-openshift-monitoring.apps.nweinber-ebpf1.qe.devcluster.openshift.com
INFO:root:TOKEN: eyJhbGciOiJSUzI1NiIsImtpZCI6IlpyY00zT2NYaUFSajhncGFCeHZTNnlFRG9aaG4xV3JXVnpJOEIwR0ZhQ2sifQ.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJvcGVuc2hpZnQtdXNlci13b3JrbG9hZC1tb25pdG9yaW5nIiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6InByb21ldGhldXMtdXNlci13b3JrbG9hZC10b2tlbi1tejRsaiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJwcm9tZXRoZXVzLXVzZXItd29ya2xvYWQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiIzNmE5ZTBmOS05MWNmLTQzMjAtYjA5Ni0zY2NiNWNmNzkyMDEiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6b3BlbnNoaWZ0LXVzZXItd29ya2xvYWQtbW9uaXRvcmluZzpwcm9tZXRoZXVzLXVzZXItd29ya2xvYWQifQ.oY36oZJgMZ4ViLTyZhNUNCWz_P4GCXBbKDQHrVMyw91EwQNumLBYZj2lSiD7T6aTOkVi_Ze4nZkqc-pUc9heUsSF-8WgN7jlxYYwQIQsjGNTEdWzNh2wyJUeh-_FMT03YjWd_vMmwZ1-9yFAN7MrDladDSw4HpLramuWvmC4i_Lp9Xr9jmq5ttIloizV95n35GLeE9vMg2CPudihBhcKgSXZNgQAqj-92wwa-zqoGVV_PwUFL7-O5TjmNLLcCyUuLaB2UkLeJ-Y9n4rcE1DOaFugRJ9aaEip96lrQgPedlETTr24P4ky-8dq12dTI2fiR81vq7dFz2J8cr5m9kHiERZRywvX4vlWl7Myo7DJ1fENJrPPOGtzFkUxVlUbjCAQrqq0movpi6IRlujVpe1tXcm2POS9sfrq7WYtywDAHuQGA37S3JwvTNMuNPg7PvIm9zCj28-5ZYthVfo1OWtzgbs9mQTcOo4XqFPQayCJ6enFZzZunrQDFAuy8BpGiMjgx3sEbKAAHU6MgZ_Pkybjga-CtbYhaLNZ-NMhF0wPcD9XjDgrMmhkY8xQwL_Y7T6z8ErGwLqK1r1YV00eUmCDjimX872JiYYqW6j0YAp2voKR_Eokpwh4QY3SivxclMteOhzy4nWRl3dq88EvRdCojo1O6uGaaVMCqAbqMnwHvtg
INFO:root:Data will be dumped locally to /Users/memodi/workspaces/repos/ocp-qe-perfscale-ci/data
INFO:root:Data captured successfully
INFO:root:Data written to /Users/memodi/workspaces/repos/ocp-qe-perfscale-ci/data/data_2022-09-09_12-39-15.json
```
```
$ jq '.data[1]' /Users/memodi/workspaces/repos/ocp-qe-perfscale-ci/data/data_2022-09-09_12-39-15.json
{
  "uuid": "1dc028ad-ff3d-48fb-bb23-7876760eeb35",
  "metric_name": "netobservEnv",
  "data_type": "metadata",
  "release": "netobserv-operator.v0.0.0-main",
  "flp_kind": "DaemonSet",
  "agent": "EBPF",
  "sampling": "1",
  "cache_active_time": "5s",
  "cache_max_flows": "1000"
}
```