### PR TITLE
Adding node name label for metrics

### DIFF
--- a/scripts/netobserv_queries_ebpf.yaml
+++ b/scripts/netobserv_queries_ebpf.yaml
@@ -1,10 +1,10 @@
 
 # 1. network-observability pods CPU usage
-- query: pod:container_cpu_usage:sum{namespace="network-observability"}
+- query: pod:container_cpu_usage:sum{namespace="network-observability"} * on (pod) group_left(node) kube_pod_info{namespace="network-observability"}
   metricName: cpuUsage
 
 # 2. eBPF pods CPU usage
-- query: pod:container_cpu_usage:sum{namespace="network-observability-privileged"}
+- query: pod:container_cpu_usage:sum{namespace="network-observability-privileged"} * on (pod) group_left(node) kube_pod_info{namespace="network-observability-privileged"}
   metricName: ebpfCpuUsage
 
 # 3. network-observability pods memory usage (Working Set)
@@ -28,7 +28,7 @@
   metricName: lokiStorageUsage
 
 # 8. Number of flows processed by ingester per minute aggregated by FLP pods.
-- query: sum(rate(ingest_collector_flow_logs_processed[1m])*60) by (pod)
+- query: sum(rate(ingest_collector_flow_logs_processed[1m])*60) by (pod) * on (pod) group_left(node) kube_pod_info{namespace="network-observability"}
   metricName: nFlowsProcessedPerMinute
 
 # 9. Number of bytes processed per minute.

--- a/scripts/netobserv_queries_ipfix.yaml
+++ b/scripts/netobserv_queries_ipfix.yaml
@@ -1,6 +1,6 @@
 
 # 1. network-observability pods CPU usage
-- query: pod:container_cpu_usage:sum{namespace="network-observability"}
+- query: pod:container_cpu_usage:sum{namespace="network-observability"} * on (pod) group_left(node) kube_pod_info{namespace="network-observability"}
   metricName: cpuUsage
 
 # 2. network-observability pods memory usage
@@ -16,7 +16,7 @@
   metricName: memoryUsageRSS
 
 # 5. Number of flows processed by ingester per minute aggregated by FLP pods.
-- query: sum(rate(ingest_collector_flow_logs_processed[1m])*60) by (pod)
+- query: sum(rate(ingest_collector_flow_logs_processed[1m])*60) by (pod) * on (pod) group_left(node) kube_pod_info{namespace="network-observability"}
   metricName: nFlowsProcessedPerMinute
 
 # 6. loki-store PVC usage averaging over 5 mins period


### PR DESCRIPTION
this would enable us to view resources and enable us to derive 1:1 correlation between flows and resources consumed by pod.
( this was discussed as action item during 09/12 NO QE Sync meeting)

Queries tested locally:

```
$ cat test_query.yaml

- query: pod:container_cpu_usage:sum{namespace="network-observability"} * on (pod) group_left(node) kube_pod_info{namespace="network-observability"}
  metricName: cpuUsage

- query: pod:container_cpu_usage:sum{namespace="network-observability-privileged"} * on (pod) group_left(node) kube_pod_info{namespace="network-observability-privileged"}
  metricName: ebpfCpuUsage

# 7. Number of flows processed by ingester per minute aggregated by FLP pods.
- query: sum(rate(ingest_collector_flow_logs_processed[1m])*60) by (pod) * on (pod) group_left(node) kube_pod_info{namespace="network-observability"}
  metricName: nFlowLogsProcessed


$ ./nope.py --starttime=1663094728 --endtime=1663094728 --dump --yaml-file=test_query.yaml --user-workloads
INFO:root:Parsed Start Time: 02:45PM UTC on 09/13/2022
INFO:root:Parsed End Time:   02:45PM UTC on 09/13/2022
INFO:root:Step is:           10
INFO:root:UUID: 44268673-d318-4979-825d-e4afc08d0778
INFO:root:YAML_FILE: test_query.yaml
INFO:root:THANOS_URL: https://thanos-querier-openshift-monitoring.apps.memodi-09131000.qe.devcluster.openshift.com
INFO:root:TOKEN: eyJhbGciOiJSUzI1NiIsImtpZCI6ImJvcUU3Q2JpVGtjbTB4YjNGNmxOaDhUcTN1WFEzcGktR3pZMzAyM0kxTXMifQ.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJvcGVuc2hpZnQtdXNlci13b3JrbG9hZC1tb25pdG9yaW5nIiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6InByb21ldGhldXMtdXNlci13b3JrbG9hZC10b2tlbi1ycTY3cCIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJwcm9tZXRoZXVzLXVzZXItd29ya2xvYWQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiI2MDViMGUwZi1iMDcyLTQwY2UtODFjMy0xMjViMTAwYmQ2ZWEiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6b3BlbnNoaWZ0LXVzZXItd29ya2xvYWQtbW9uaXRvcmluZzpwcm9tZXRoZXVzLXVzZXItd29ya2xvYWQifQ.2hgvzu8FPoA8_Smymui3IKA0OyETg6aILYP9S3ONn9N60lE7VbxDfB3b6debNNX4-ehiEGssRdiOOUXw7xmoBWbShAK2WYYkWH4VR8F6mA413ax0otq8qbd_4tF__AwbSG-4Is7QyHbrsUU-csujYQm5DqjiKyOHJsUpgmPrlJ455pzqK8Vvlj2LIYrcOakfDg0_G3j5BnuP2vSRd_L0zXCMt8S3T2N_OjTZ304sJvXOsEwf1_9QS78mhYZd5wkokNci2gxGNS_61D5YEgo3cFOn1I6Yn4pPUZJ4qqOnh-hDSiYYW9zQGVCZ3e-J61S2P9W4AKYbx1j9OXLHbVJtafW1LbNrPeOcBoXuMZRg91fPr4SFJbx3tZ7Gx7nSuvRVtxEZ_ooUA6VzPHkScXSei2QwUOvdDajia7dwUa0JcqBBNs8yjvKnGiJL7UBSyDZ8N7JTJdPnfZ9rZ7rub6bu4zLRRLy5V70J0Gl922Yo6PrSSWNMmNtRRLaSLTz5EiePlT_GfZLWq2HW5X1t5cIF3KUcuQbohjLm6VprIShrHY_RinD_pC0yvybPk7dLKcPzKzWHbSaSnsp6Hm5_DJutZ761_AU1r8vdfbzZpxlPZUTXVqe-FWiSaq8oQTaRaJfyUf7VU5mbj7Zry_zQCav-e5ZY-9cjQb9r9vgco_ExOsw
INFO:root:Data will be dumped locally to /Users/memodi/workspaces/repos/ocp-qe-perfscale-ci/data
INFO:root:Data captured successfully
INFO:root:Data written to /Users/memodi/workspaces/repos/ocp-qe-perfscale-ci/data/data_2022-09-13_15-01-17.json

$ jq '.data[1]' < /Users/memodi/workspaces/repos/ocp-qe-perfscale-ci/data/data_2022-09-13_15-01-17.json
{
  "uuid": "44268673-d318-4979-825d-e4afc08d0778",
  "metric_name": "cpuUsage",
  "data_type": "datapoint",
  "unix_timestamp": 1663094728,
  "value": 0.010287359925925917,
  "metadata": {
    "namespace": "network-observability",
    "node": "ip-10-0-134-185.us-east-2.compute.internal",
    "pod": "flowlogs-pipeline-6x9kh",
    "prometheus": "openshift-monitoring/k8s",
    "query": "pod:container_cpu_usage:sum{namespace=\"network-observability\"} * on (pod) group_left(node) kube_pod_info{namespace=\"network-observability\"}"
  }
}
```