### PR TITLE
Taking out check of workload projects

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -178,7 +178,7 @@ pipeline {
           if (status != "PASS" && fileExists("inspect_data")) {
              archiveArtifacts artifacts: 'inspect_data/*,inspect_data/**', fingerprint: false
           }
-          if (fileExists("cerberus_jenkins/failed_pods")) {
+          if (fileExists("cerberus_jenkins/failed_pods/*")) {
              archiveArtifacts artifacts: 'cerberus_jenkins/failed_pods/*,cerberus_jenkins/failed_pods/**', fingerprint: false
           }
        }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,11 @@ pipeline {
             description: "Which specific namespaces you want to watch any failing components, use [^.*\$] if you want to watch all namespaces"
         )
         string(
+            name: "WORKLOAD",
+            defaultValue: "", 
+            description: "Specify the workload if you created more than 5000 pods in a namespace, will ignore the namespaces in cerberus check"
+        )
+        string(
             name: "CERBERUS_IGNORE_PODS",
             defaultValue: "[^installer*]", 
             description: "Which specific pod names regex patterns you want to ignore in the namespaces you defined above"
@@ -92,6 +97,19 @@ pipeline {
           doGenerateSubmoduleConfigurations: false,
           userRemoteConfigs: [[url: params.CERBERUS_REPO ]
          ]])
+        checkout([
+            $class: 'GitSCM',
+            branches: [[name: GIT_BRANCH ]],
+            doGenerateSubmoduleConfigurations: false,
+            extensions: [
+                [$class: 'CloneOption', noTags: true, reference: '', shallow: true],
+                [$class: 'PruneStaleBranch'],
+                [$class: 'CleanCheckout'],
+                [$class: 'IgnoreNotifyCommit'],
+                [$class: 'RelativeTargetDirectory', relativeTargetDir: 'cerberus_jenkins']
+            ],
+            userRemoteConfigs: [[url: GIT_URL ]]
+        ])
         copyArtifacts(
             filter: '',
             fingerprintArtifacts: true,
@@ -108,6 +126,7 @@ pipeline {
 
         script {
           RETURNSTATUS = sh(returnStatus: true, script: '''
+          ls
           wget https://raw.githubusercontent.com/redhat-chaos/krkn-hub/main/cerberus/env.sh
           source env.sh
           # Get ENV VARS Supplied by the user to this job and store in .env_override
@@ -117,23 +136,33 @@ pipeline {
           mkdir -p ~/.kube
           cp $WORKSPACE/flexy-artifacts/workdir/install-dir/auth/kubeconfig ~/.kube/config
           export CERBERUS_KUBECONFIG=~/.kube/config
-          project_count=$(oc get project | wc -l)
+        
           export CERBERUS_CORES=.05
-
+          cd cerberus_jenkins
+          python3.9 --version
+          python3.9 -m venv venv3
+          source venv3/bin/activate
+          if [[ $CERBERUS_WATCH_NAMESPACES == '[^.*$]' ]]; then
+            ls
+            export CERBERUS_WATCH_NAMESPACES=$(python set_namespace_list.py -w $WORKLOAD)
+          fi
+          cd ..
           env
           wget https://raw.githubusercontent.com/redhat-chaos/krkn-hub/main/cerberus/cerberus.yaml.template
           envsubst <cerberus.yaml.template > cerberus.yaml
-          python3 --version
-          python3 -m venv venv3
-          source venv3/bin/activate
+          
           pip --version
           pip install --upgrade pip
           pip install -U -r requirements.txt
+          export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
           python start_cerberus.py --config cerberus.yaml
           replaced_json=$(less -XF final_cerberus_info.json | sed "s/True/0/g" | sed "s/False/1/g" )
           value=${replaced_json#*:*:}   # remove prefix ending at second ":"
           final_health=${value%,*}  # remove suffix starting with ","
           echo "health $final_health"
+          cd cerberus_jenkins
+          python -c "import check_kube_burner_ns; check_kube_burner_ns.check_namespaces( '$WORKLOAD' )"
+          cd ..
           exit $final_health
 
           ''')
@@ -148,6 +177,9 @@ pipeline {
       script {
           if (status != "PASS" && fileExists("inspect_data")) {
              archiveArtifacts artifacts: 'inspect_data/*,inspect_data/**', fingerprint: false
+          }
+          if (fileExists("cerberus_jenkins/failed_pods")) {
+             archiveArtifacts artifacts: 'cerberus_jenkins/failed_pods/*,cerberus_jenkins/failed_pods/**', fingerprint: false
           }
        }
 

--- a/check_kube_burner_ns.py
+++ b/check_kube_burner_ns.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+import subprocess
+
+all_namespaces= []
+
+# Invokes a given command and returns the stdout
+def invoke(command):
+    try:
+        output = subprocess.check_output(command, shell=True, universal_newlines=True)
+    except subprocess.CalledProcessError as exc:
+        print("Status : FAIL", exc.returncode, exc.output)
+        return exc.output
+    print(output )
+    return output
+
+def get_kube_burner_namespaces(workload): 
+    namespaces = invoke("oc get ns --no-headers -l kube-burner-job=%s | awk '{print$1}'" % workload)
+    global all_namespaces
+    for n in namespaces.split():
+        all_namespaces.append(n)
+
+def get_failed_pods(namespace): 
+    pod_names = invoke("oc get pods -n %s --no-headers | grep -v Running | awk '{print$1}'" % namespace)
+    if pod_names:
+        print('make namespace')
+        invoke("mkdir failed_pods/" + str(namespace))
+    for p in pod_names.split():
+        invoke("oc logs %s -n %s >> failed_pods/%s/%s_logs.out" % (p, namespace, namespace, p))
+        break
+
+def check_namespaces(workload):
+    if not workload:
+        return
+    invoke('mkdir failed_pods')
+    get_kube_burner_namespaces(workload)
+    for n in all_namespaces:
+        get_failed_pods(n)

--- a/check_kube_burner_ns.py
+++ b/check_kube_burner_ns.py
@@ -20,7 +20,7 @@ def get_kube_burner_namespaces(workload):
         all_namespaces.append(n)
 
 def get_failed_pods(namespace): 
-    pod_names = invoke("oc get pods -n %s --no-headers | grep -v Running | awk '{print$1}'" % namespace)
+    pod_names = invoke("oc get pods -n %s --no-headers | grep -v Running | grep -v Completed  | awk '{print$1}'" % namespace)
     if pod_names:
         print('make namespace')
         invoke("mkdir failed_pods/" + str(namespace))

--- a/check_kube_burner_ns.py
+++ b/check_kube_burner_ns.py
@@ -11,7 +11,6 @@ def invoke(command):
     except subprocess.CalledProcessError as exc:
         print("Status : FAIL", exc.returncode, exc.output)
         return exc.output
-    print(output )
     return output
 
 def get_kube_burner_namespaces(workload): 
@@ -27,12 +26,13 @@ def get_failed_pods(namespace):
         invoke("mkdir failed_pods/" + str(namespace))
     for p in pod_names.split():
         invoke("oc logs %s -n %s >> failed_pods/%s/%s_logs.out" % (p, namespace, namespace, p))
-        break
 
 def check_namespaces(workload):
     if not workload:
         return
     invoke('mkdir failed_pods')
+    if workload == "pod-density":
+        workload = "node-density"
     get_kube_burner_namespaces(workload)
     for n in all_namespaces:
         get_failed_pods(n)

--- a/set_namespace_list.py
+++ b/set_namespace_list.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+import subprocess
+import argparse
+
+all_namespaces= []
+
+# Invokes a given command and returns the stdout
+def invoke(command):
+    try:
+        output = subprocess.check_output(command, shell=True, universal_newlines=True)
+    except subprocess.CalledProcessError as exc:
+        print("Status : FAIL", exc.returncode, exc.output)
+        return exc.output
+    return output
+
+
+def get_all_namespaces(): 
+    namespaces = invoke("oc get ns --no-headers | awk '{print$1}'")
+    global all_namespaces
+    for n in namespaces.split(): 
+        all_namespaces.append(n)
+
+def get_kube_burner_namespaces(workload): 
+    namespaces = invoke("oc get ns --no-headers -l kube-burner-job=%s | awk '{print$1}'" % workload)
+    global all_namespaces
+    for n in namespaces.split():
+        all_namespaces.remove(n)
+
+
+def get_namespace_list(workload):
+    get_all_namespaces()
+    if workload:
+        get_kube_burner_namespaces(workload)
+    global all_namespaces
+    str_all_namespaces = '[' + ', '.join(all_namespaces) + ']'
+    print(str_all_namespaces)
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--workload", "-w", type=str, default='', help='Kube-burner workload type')
+arg = parser.parse_args()
+get_namespace_list(arg.workload)

--- a/set_namespace_list.py
+++ b/set_namespace_list.py
@@ -31,6 +31,8 @@ def get_kube_burner_namespaces(workload):
 def get_namespace_list(workload):
     get_all_namespaces()
     if workload:
+        if workload == "pod-density":
+            workload = "node-density"
         get_kube_burner_namespaces(workload)
     global all_namespaces
     str_all_namespaces = '[' + ', '.join(all_namespaces) + ']'


### PR DESCRIPTION
When there are too many pod in namespace, cerberus in jenkins doesn't have enough computer power or memory to finish the cerberus run on those pods. If all namespaces are given, we are going to remove the namespace that matches the workload type 

Doing a separate check at the end to see if any of the pods are not running and getting their logs

See it in action here https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/paige-e2e-multibranch/job/cerberus/281/

Note: the kube burner job itself will also fail if any of the pods go not ready. We are really wanting to check in this case if any of the cluster components are failing 