### PR TITLE
Adding blank option to cleanup 

### DIFF
--- a/cleanup.py
+++ b/cleanup.py
@@ -28,7 +28,9 @@ def delete_all_namespaces(job):
     print("job type " + str(job))
     if job.lower() == "pod-density":
         job = "node-density"
-    invoke("oc delete ns --wait=false -l kube-burner-job=" + job)
+    if job:
+        job = "=" + job
+    invoke("oc delete ns --wait=false -l kube-burner-job" + job)
     wait_for_all_deleted_ns(job)
 
 def wait_for_all_deleted_ns(job, wait_num=300):
@@ -46,4 +48,3 @@ def wait_for_all_deleted_ns(job, wait_num=300):
         time.sleep(10)
     invoke("oc get ns")
     return 0
-


### PR DESCRIPTION
If the user doesn't pass a workload it'll delete all namespaces that have the label "kube-burner-job" but doesn't matter what the workload type is. This will be very useful for all the custom workloads we are adding to regression-test type

Example: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/paige-e2e-multibranch/job/benchmark-cleaner/19/console