### PR TITLE
Updating metrics to generate

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,7 +107,7 @@ pipeline {
         )
         string(
             name: "COMPARISON_CONFIG",
-            defaultValue: "clusterVersion.json podLatency.json podCPU-avg.json podCPU-max.json podMemory-avg.json podMemory-max.json",
+            defaultValue: "clusterVersion.json podLatency.json containerMetrics.json",
             description: 'JSON files of what data to output into a google sheet'
         )
         booleanParam(


### PR DESCRIPTION
With [PR](https://github.com/cloud-bulldozer/e2e-benchmarking/pull/411#event-7495808244) we decided to move to using container CPU and container memory because those metrics were already being captured. So we now need to update the csv generator with that data instead of pods