### PR TITLE
Printing all output to file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -244,7 +244,7 @@ pipeline {
                             export PODS_PER_NODE=$VARIABLE
                             fi
                             set -o pipefail
-                            ./run.sh | tee "kube-burner.out"
+                            ./run.sh |& tee "kube-burner.out"
                         ''')
                         output = sh(returnStdout: true, script: 'cat workloads/kube-burner/kube-burner.out')
                         if (RETURNSTATUS.toInteger() == 0) {


### PR DESCRIPTION
Get all stdout from new kube-burner sub run to pass to write to scale properly

https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/paige-e2e-multibranch/job/kube-burner/97/console
Can see that all the output gets to the JOB_OUTPUT variable here: 
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/write-scale-ci-results/3057/parameters/
vs. 
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/write-scale-ci-results/3032/parameters/
Missing kube burner output