### PR TITLE
Get all output in output file 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -170,7 +170,7 @@ pipeline {
 
             export WORKLOAD=$WORKLOAD_TYPE
             set -o pipefail
-            ./run.sh | tee "network-perf.out"
+            ./run.sh |& tee "network-perf.out"
             ''')
             output = sh(returnStdout: true, script: 'cat workloads/network-perf/network-perf.out')
             if (RETURNSTATUS.toInteger() == 0) {


### PR DESCRIPTION
Get all output from runs: similar to router-perf and kube-burner updates

https://github.com/openshift-qe/ocp-qe-perfscale-ci/pull/286