### PR TITLE
Write scale ci results with no benchmark-operator

### DIFF
--- a/write_to_sheet/write_scale_results_sheet.py
+++ b/write_to_sheet/write_scale_results_sheet.py
@@ -23,7 +23,7 @@ def get_benchmark_uuid(env_vars_file):
         if "kube-burner-uuid" in namespace_json['metadata']['labels']:
             global uuid
             uuid = namespace_json['metadata']['labels']['kube-burner-uuid']
-            #if mutliple not sure what to do
+            #if multiple not sure what to do
             creation_time = namespace_json['metadata']['creationTimestamp']
             # "2021-08-10T13:53:20Z"
             d = datetime.strptime(creation_time[:-1], "%Y-%m-%dT%H:%M:%S")

--- a/write_to_sheet/write_scale_results_sheet.py
+++ b/write_to_sheet/write_scale_results_sheet.py
@@ -15,7 +15,7 @@ data_source = "Development-AWS-ES_ripsaw-kube-burner"
 uuid = ""
 def get_benchmark_uuid(env_vars_file):
     return_code, namespace = write_helper.run("oc get ns -l kube-burner-uuid -o name --sort-by='.metadata.creationTimestamp' --no-headers | head -1")
-    print('namesapce ' + str(namespace))
+    print('namespace ' + str(namespace))
     return_code, namespace_str = write_helper.run("oc get " + namespace.strip() + " -o json")
     print("namespace_str " + str(namespace_str))
     if return_code == 0:


### PR DESCRIPTION
Getting uuid from namespaces created labels because there are no benchmark objects 

Need new way to get time of start of run

successful run: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/paige-e2e-multibranch/job/write-scale-ci-results/140/console