### PR TITLE
Fixed Mr. Sandman

### DIFF
--- a/scripts/sandman.py
+++ b/scripts/sandman.py
@@ -20,25 +20,27 @@ def main():
         workload_logs = out_file.read()
 
     # initialize regexs
-    base_regex = '([a-zA-z]{3}\s+\d+ \d+:\d+:\d+ [a-zA-z]{3} \d+).*'
     if "kube-burner" in WORKLOAD_OUT_FILE:
-        starttime_regex = base_regex + 'Deploying'
-        endtime_regex = base_regex + 'Indexing'
+        base_regex = 'time="(\d+-\d+-\d+ \d+:\d+:\d+)".*'
+        starttime_regex = base_regex + 'Starting'
+        endtime_regex = base_regex + 'Exiting'
+        strptime_filter = '%Y-%m-%d %H:%M:%S'
     elif "ingress_router" in WORKLOAD_OUT_FILE:
+        base_regex = '([a-zA-z]{3}\s+\d+ \d+:\d+:\d+ [a-zA-z]{3} \d+).*'
         starttime_regex = base_regex + 'Testing'
         endtime_regex = base_regex + 'Enabling'
-    uuid_regex = 'UUID: (.*)\n'
+        strptime_filter = '%b %d %H:%M:%S %Z %Y'
+    uuid_regex = 'UUID: (.*)"'
 
     # capture and log strings representations of start and end times
     starttime_string = re.findall(starttime_regex, workload_logs)[0]
     endtime_string = re.findall(endtime_regex, workload_logs)[0]
-    uuid = re.findall(uuid_regex, workload_logs)[-1]
+    uuid = re.findall(uuid_regex, workload_logs)[0]
     print(f"uuid: {uuid}")
     print(f"starttime_string: {starttime_string}")
     print(f"endtime_string: {endtime_string}")
 
     # convert string times to unix timestamps
-    strptime_filter = '%b %d %H:%M:%S %Z %Y'
     starttime_timestamp = int(datetime.datetime.strptime(starttime_string, strptime_filter).replace(tzinfo=datetime.timezone.utc).timestamp())
     endtime_timestamp = int(datetime.datetime.strptime(endtime_string, strptime_filter).replace(tzinfo=datetime.timezone.utc).timestamp())
     print(f"starttime_timestamp: {starttime_timestamp}")


### PR DESCRIPTION
https://github.com/cloud-bulldozer/e2e-benchmarking/pull/475 broke Mr. Sandman due to changes in how `.out` files are generated - this PR addresses this regression

## Test Data
### kube-burner
File: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/paige-e2e-multibranch/job/kube-burner/97/artifact/workloads/kube-burner/kube-burner.out/*view*/
Sandman:
```bash
[nathan@nathan-redhat ocp-qe-perfscale-ci (sandman)]$ ./scripts/sandman.py --file kube-burner.out
uuid: 773bc169-4368-4f66-869b-2ceeb97c9cd8
starttime_string: 2022-10-05 15:21:05
endtime_string: 2022-10-05 15:26:17
starttime_timestamp: 1664983265
endtime_timestamp: 1664983577
```

### router-perf
File: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/router-perf/685/artifact/workloads/router-perf-v2/ingress_router.out/*view*/
Sandman:
```bash
[nathan@nathan-redhat ocp-qe-perfscale-ci (sandman)]$ ./scripts/sandman.py --file ingress_router.out 
uuid: 2ad9405a-1c18-4fb1-a4e3-5e4a3180b27a
starttime_string: Oct  5 17:42:26 UTC 2022
endtime_string: Oct  5 17:50:01 UTC 2022
starttime_timestamp: 1664991746
endtime_timestamp: 1664992201
```