### PR TITLE
changes for NETOBSERV-660 and re-ordering Kafka steps.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -394,7 +394,6 @@ pipeline {
                     if (params.ENABLE_KAFKA == true) {
                         println "Enabling Kafka in flowcollector..."
                         returnCode = sh(returnStatus: true, script: """
-                            oc patch flowcollector cluster --type=json -p "[{"op": "replace", "path": "/spec/deploymentModel", "value": "KAFKA"}] -n netobserv"
                             source $WORKSPACE/ocp-qe-perfscale-ci/scripts/netobserv.sh
                             deploy_kafka
                         """)

--- a/scripts/flows_v1alpha1_flowcollector_lokistack.yaml
+++ b/scripts/flows_v1alpha1_flowcollector_lokistack.yaml
@@ -35,10 +35,11 @@ spec:
     enableKubeProbes: true
     healthPort: 8080
     profilePort: 6060
-    metricsServer:
-      port: 9102
-    ignoreMetrics:
-    - egress
+    metrics:
+      server:
+        port: 9102
+      ignoreTags:
+        - egress
     dropUnusedFields: true
     kafkaConsumerReplicas: 3
     kafkaConsumerAutoscaler: null

--- a/scripts/flows_v1alpha1_flowcollector_versioned_lokistack.yaml
+++ b/scripts/flows_v1alpha1_flowcollector_versioned_lokistack.yaml
@@ -28,9 +28,11 @@ spec:
     logLevel: info
     enableKubeProbes: true
     healthPort: 8080
-    prometheusPort: 9102
-    ignoreMetrics:
-    - egress
+    metrics:
+      server:
+        port: 9102
+      ignoreTags:
+        - egress
     dropUnusedFields: true
   kafka:
     enable: false

--- a/scripts/netobserv.sh
+++ b/scripts/netobserv.sh
@@ -122,6 +122,8 @@ deploy_kafka() {
   oc apply -f $TMP_KAFKA_TOPIC -n ${NAMESPACE}
   oc wait --timeout=180s --for=condition=ready kafkatopic network-flows -n ${NAMESPACE}
 
+  oc patch flowcollector cluster --type=json -p "[{"op": "replace", "path": "/spec/deploymentModel", "value": "KAFKA"}]"
+
   # updated FLP replicas # if different than already configured.
   FLP_REPLICAS=$(oc get flowcollector/cluster -o jsonpath='{.spec.processor.kafkaConsumerReplicas}')
   if [[ "$FLP_KAFKA_REPLICAS" != "$FLP_REPLICAS" ]]; then


### PR DESCRIPTION
1. re-order Kafka steps to prevent from running into issue [NETOBSERV-575](https://issues.redhat.com/browse/NETOBSERV-575)
2. NETOBSERV-660 changed metrics section.

cc @nathan-weinberg - minor changes IMO, please review and let me know if you need success run.