### PR TITLE
Write scale ci results

### DIFF
--- a/write_to_sheet/write_helper.py
+++ b/write_to_sheet/write_helper.py
@@ -75,7 +75,7 @@ def get_oc_version():
         print("Error getting clusterversion")
 
 def flexy_install_type(flexy_url):
-    return_code, version_type_string = run('curl -s {}/consoleFull | grep "run_installer template -c private-templates/functionality-testing/aos-"'.format(flexy_url))
+    return_code, version_type_string = run('curl --noproxy "*" -s {}/consoleFull | grep "run_installer template -c private-templates/functionality-testing/aos-"'.format(flexy_url))
     if return_code == 0:
         version_lists = version_type_string.split("-on-")
         cloud_type = version_lists[1].split('/')[0]

--- a/write_to_sheet/write_scale_results_sheet.py
+++ b/write_to_sheet/write_scale_results_sheet.py
@@ -33,6 +33,7 @@ def get_benchmark_uuid(env_vars_file):
             to_time = calendar.timegm(n_time.timetuple()) * 1000
             if "ES_SERVER" in env_vars_file: 
                 if "search-ocp-qe-perf-scale-test" in env_vars_file:
+                    global data_source
                     data_source = "SVTQE-kube-burner"
                 return get_grafana_url(uuid, from_time, to_time)
             return ""
@@ -182,7 +183,7 @@ def write_to_sheet(google_sheet_account, flexy_id, ci_job, job_type, job_url, st
         else:
             grafana_cell = ""
     else:
-        grafana_cell = get_benchmark_uuid()
+        grafana_cell = get_benchmark_uuid(env_vars_file)
         if not grafana_cell:
             grafana_cell = get_metadata_uuid(job_type, job_output)
 


### PR DESCRIPTION
Missing env_vars_file when writing results to sheet

Results of runs can be seen in the cluster-density tab

## Fixes
no results were being written for kube-burner type jobs