### PR TITLE
Getting resourceID from existing machineset.

### DIFF
--- a/infra-node-machineset-azure-customervpc.yaml
+++ b/infra-node-machineset-azure-customervpc.yaml
@@ -39,7 +39,7 @@ items:
             image:
               offer: ""
               publisher: ""
-              resourceID: /resourceGroups/${CLUSTER_NAME}-rg/providers/Microsoft.Compute/images/${CLUSTER_NAME}-gen2
+              resourceID: ${RESOURCE_ID}
               sku: ""
               version: ""
             internalLoadBalancer: ""
@@ -105,7 +105,7 @@ items:
             image:
               offer: ""
               publisher: ""
-              resourceID: /resourceGroups/${CLUSTER_NAME}-rg/providers/Microsoft.Compute/images/${CLUSTER_NAME}-gen2
+              resourceID: ${RESOURCE_ID}
               sku: ""
               version: ""
             internalLoadBalancer: ""
@@ -171,7 +171,7 @@ items:
             image:
               offer: ""
               publisher: ""
-              resourceID: /resourceGroups/${CLUSTER_NAME}-rg/providers/Microsoft.Compute/images/${CLUSTER_NAME}-gen2
+              resourceID: ${RESOURCE_ID}
               sku: ""
               version: ""
             internalLoadBalancer: ""

--- a/infra-node-machineset-azure.yaml
+++ b/infra-node-machineset-azure.yaml
@@ -38,7 +38,7 @@ items:
             image:
               offer: ""
               publisher: ""
-              resourceID: /resourceGroups/${CLUSTER_NAME}-rg/providers/Microsoft.Compute/images/${CLUSTER_NAME}
+              resourceID: ${RESOURCE_ID}
               sku: ""
               version: ""
             internalLoadBalancer: ""
@@ -105,7 +105,7 @@ items:
             image:
               offer: ""
               publisher: ""
-              resourceID: /resourceGroups/${CLUSTER_NAME}-rg/providers/Microsoft.Compute/images/${CLUSTER_NAME}
+              resourceID: ${RESOURCE_ID}
               sku: ""
               version: ""
             internalLoadBalancer: ""
@@ -172,7 +172,7 @@ items:
             image:
               offer: ""
               publisher: ""
-              resourceID: /resourceGroups/${CLUSTER_NAME}-rg/providers/Microsoft.Compute/images/${CLUSTER_NAME}
+              resourceID: ${RESOURCE_ID}
               sku: ""
               version: ""
             internalLoadBalancer: ""

--- a/install_infra_work.sh
+++ b/install_infra_work.sh
@@ -71,6 +71,7 @@ elif [[ $(echo $VARIABLES_LOCATION | grep azure -c) > 0 ]]; then
     export NETWORK_RESOURCE_GROUP_ID=$(oc get machineset -n openshift-machine-api -o=go-template='{{(index .items 0).spec.template.spec.providerSpec.value.networkResourceGroup}}')
     export VNET_ID=$(oc get machineset -n openshift-machine-api -o=go-template='{{(index .items 0).spec.template.spec.providerSpec.value.vnet}}')
     export SUBNET_ID=$(oc get machineset -n openshift-machine-api -o=go-template='{{(index (index .items 0).spec.template.spec.providerSpec.value.subnet)}}')
+    export RESOURCE_ID=$(oc get machineset -n openshift-machine-api -o=go-template='{{(index (index .items 0).spec.template.spec.providerSpec.value.image.resourceID)}}')
     if [[ $(echo $NETWORK_RESOURCE_GROUP_ID | grep $CLUSTER_NAME -c) > 0 ]]; then
         envsubst < infra-node-machineset-azure.yaml | oc apply -f -
         envsubst < workload-node-machineset-azure.yaml | oc apply -f -

--- a/workload-node-machineset-azure-customervpc.yaml
+++ b/workload-node-machineset-azure-customervpc.yaml
@@ -37,7 +37,7 @@ spec:
           image:
             offer: ""
             publisher: ""
-            resourceID: /resourceGroups/${CLUSTER_NAME}-rg/providers/Microsoft.Compute/images/${CLUSTER_NAME}-gen2
+            resourceID: ${RESOURCE_ID}
             sku: ""
             version: ""
           internalLoadBalancer: ""

--- a/workload-node-machineset-azure.yaml
+++ b/workload-node-machineset-azure.yaml
@@ -36,7 +36,7 @@ spec:
           image:
             offer: ""
             publisher: ""
-            resourceID: /resourceGroups/${CLUSTER_NAME}-rg/providers/Microsoft.Compute/images/${CLUSTER_NAME}
+            resourceID: ${RESOURCE_ID}
             sku: ""
             version: ""
           internalLoadBalancer: ""


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/OCPQE-12540

Tested with 4.11:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Flexy-install/148718/
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/skordas-e2e-bmp/job/cluster-post-config-412azure/2/console
and 4.12:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Flexy-install/148722/
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/skordas-e2e-bmp/job/cluster-post-config-412azure/3/console

^^ jobs are failing due statefulset-controller issue - but infra nodes are provisioned correcttly.