### PR TITLE
Updated Jenkinsfile and shell scripts, some CRD configs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -381,7 +381,7 @@ pipeline {
                     }
                     println "Checking if Kafka needs to be enabled or updated..."
                     if (params.ENABLE_KAFKA == true) {
-                        println "Enabling Kafka in flowcollector..."
+                        println "Configuring Kafka in flowcollector..."
                         returnCode = sh(returnStatus: true, script: """
                             source $WORKSPACE/ocp-qe-perfscale-ci/scripts/netobserv.sh
                             deploy_kafka

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -35,7 +35,7 @@ To install from Operator Hub, navigate to the `scripts/` directory and run `$ IN
 #### Source
 GitHub Actions is used to [build and push images from the upstream operator repository](https://github.com/netobserv/network-observability-operator/actions) to [quay.io](https://quay.io/repository/netobserv/network-observability-operator-catalog?tab=tags) where the `vmain` tag is used to track the Github `main` branch.
 
-To install from Source, navigate to the `scripts/` directory and run `$ INSTALLATION_SOURCE=Source; source netobserv.sh ; deploy_main_catalogsource; deploy_netobserv`
+To install from Source, navigate to the `scripts/` directory and run `$ INSTALLATION_SOURCE=Source; source netobserv.sh ; deploy_netobserv`
 
 ### Creating LokiStack using Loki Operator
 It is recommended to use Loki operator to create a LokiStack for Network Observability. `$ deploy_netobserv` function in [section](#installing-the-network-observability-operator) takes care of deploying LokiStack. To create LokiStack manually, the following steps can be performed:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,7 +24,7 @@ Below are the metrics that are collected as part of the tests:
 $ oc whoami
 kube:admin
 ```
-3. Navigate to the parent directory of `ocp-qe-perfscale-ci` and run `export WORKSPACE=$PWD`
+3. Depending on which functions within `netobserv.sh` you plan to use, you may also need to install the AWS CLI and properly set your credentials
 
 ### Installing the Network Observability Operator
 There are two methods you can use to install the operator:

--- a/scripts/deploy-loki-aws-secret.sh
+++ b/scripts/deploy-loki-aws-secret.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 LOKI_BUCKET_NAME=${1:-netobserv-loki-ocpqe-perf}
 NAMESPACE=openshift-operators-redhat
 SECRETNAME="s3-secret"

--- a/scripts/flows_v1alpha1_flowcollector_lokistack.yaml
+++ b/scripts/flows_v1alpha1_flowcollector_lokistack.yaml
@@ -22,7 +22,7 @@ spec:
       imagePullPolicy: Always
       sampling: 1
       cacheActiveTimeout: 5s
-      cacheMaxFlows: 1000
+      cacheMaxFlows: 100000
       interfaces: [ ]
       excludeInterfaces: [ "lo" ]
       logLevel: info

--- a/scripts/flows_v1alpha1_flowcollector_lokistack.yaml
+++ b/scripts/flows_v1alpha1_flowcollector_lokistack.yaml
@@ -79,7 +79,9 @@ spec:
     imagePullPolicy: Always
     port: 9001
     logLevel: info
-    autoscaler: null
+    autoscaler:
+      maxReplicas: 0
+      status: DISABLED
     portNaming:
       enable: true
       portNames:

--- a/scripts/flows_v1alpha1_flowcollector_versioned_lokistack.yaml
+++ b/scripts/flows_v1alpha1_flowcollector_versioned_lokistack.yaml
@@ -22,7 +22,7 @@ spec:
       imagePullPolicy: Always
       sampling: 1
       cacheActiveTimeout: 5s
-      cacheMaxFlows: 1000
+      cacheMaxFlows: 100000
       interfaces: [ ]
       excludeInterfaces: [ "lo" ]
       logLevel: info

--- a/scripts/netobserv.sh
+++ b/scripts/netobserv.sh
@@ -1,17 +1,26 @@
+#!/usr/bin/env bash
+
 NAMESPACE=${1:-netobserv}
+SCRIPTS_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 export DEFAULT_SC=$(oc get storageclass -o=jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
-SCRIPTS_DIR=$WORKSPACE/ocp-qe-perfscale-ci/scripts
 if [[ "${INSTALLATION_SOURCE}" == "OperatorHub" ]]; then
-  echo "Using OperatorHub for installing NOO"
+  echo "Using 'OperatorHub' as INSTALLATION_SOURCE"
   NOO_SUBSCRIPTION=$SCRIPTS_DIR/noo-released-subscription.yaml
   FLOWCOLLECTOR=$SCRIPTS_DIR/flows_v1alpha1_flowcollector_versioned_lokistack.yaml
 elif [[ "${INSTALLATION_SOURCE}" == "Source" ]]; then
-  echo "Using Source for installing NOO"
+  echo "Using 'Source' as INSTALLATION_SOURCE"
   NOO_SUBSCRIPTION=$SCRIPTS_DIR/noo-main-subscription.yaml
   FLOWCOLLECTOR=$SCRIPTS_DIR/flows_v1alpha1_flowcollector_lokistack.yaml
+else
+  echo "Please set INSTALLATION_SOURCE env variable to either 'OperatorHub' or 'Source' if you intend to use the 'deploy_netobserv' function" 
 fi
 
 deploy_netobserv() {
+  echo "====> Deploying NetObserv"
+  if [[ "${INSTALLATION_SOURCE}" == "Source" ]]; then
+    deploy_main_catalogsource
+  fi
+  echo "====> Creating NetObserv Project, OperatorGroup, and Subscription"
   oc new-project ${NAMESPACE} || true
   oc apply -f $SCRIPTS_DIR/operator_group.yaml
   oc apply -f $NOO_SUBSCRIPTION
@@ -21,6 +30,7 @@ deploy_netobserv() {
     oc get crd/flowcollectors.flows.netobserv.io && break
     sleep 1
   done
+  echo "====> Creating flowlogs-pipeline"
   oc apply -f $FLOWCOLLECTOR
   echo "====> Waiting for flowlogs-pipeline pod to be ready"
   while :; do
@@ -33,54 +43,15 @@ deploy_netobserv() {
 }
 
 deploy_main_catalogsource() {
-  echo "deploying netobserv operator and flowcollector CR"
-  # creating catalog source from the main bundle
+  echo "====> Creating netobserv-testing CatalogSource from the main bundle"
   oc apply -f $SCRIPTS_DIR/netobserv-catalogsource.yaml
   sleep 30
   oc wait --timeout=180s --for=condition=ready pod -l olm.catalogSource=netobserv-testing -n openshift-marketplace
 }
 
-deploy_loki() {
-  oc apply -f $SCRIPTS_DIR/loki-storage-1.yaml
-  oc apply -f $SCRIPTS_DIR/loki-storage-2.yaml
-  oc wait --timeout=120s --for=condition=ready pod -l app=loki -n ${NAMESPACE}
-  echo "loki is deployed"
-}
-
-delete_flowcollector() {
-  echo "deleting flowcollector"
-  oc delete flowcollector/cluster
-}
-
-uninstall_netobserv() {
-  oc delete --ignore-not-found flowcollector/cluster
-  oc delete -f $NOO_SUBSCRIPTION
-  oc delete csv -l operators.coreos.com/netobserv-operator.${NAMESPACE}
-  oc delete -f $SCRIPTS_DIR/operator_group.yaml
-  oc delete project ${NAMESPACE}
-  oc delete --ignore-not-found catalogsource/netobserv-testing -n openshift-marketplace
-}
-
-populate_netobserv_metrics() {
-  oc apply -f $SCRIPTS_DIR/cluster-monitoring-config.yaml
-  if [[ "${ENABLE_KAFKA}" == "true" ]]; then
-    oc apply -f $SCRIPTS_DIR/service-monitor-kafka.yaml
-  else
-    oc apply -f $SCRIPTS_DIR/service-monitor.yaml
-  fi
-  echo "Added ServiceMonitor for NetObserv prometheus metrics"
-}
-
-setup_dittybopper_template() {
-  sleep 30
-  oc wait --timeout=120s --for=condition=ready pod -n openshift-user-workload-monitoring -l app.kubernetes.io/component=controller
-  oc wait --timeout=120s --for=condition=ready pod -n openshift-user-workload-monitoring -l app.kubernetes.io/managed-by=prometheus-operator
-  export PROMETHEUS_USER_WORKLOAD_BEARER=$(oc sa get-token prometheus-user-workload -n openshift-user-workload-monitoring || oc sa new-token prometheus-user-workload -n openshift-user-workload-monitoring)
-  export THANOS_URL=https://$(oc get route thanos-querier -n openshift-monitoring -o json | jq -r '.spec.host')
-  envsubst "${PROMETHEUS_USER_WORKLOAD_BEARER} ${THANOS_URL}" <$SCRIPTS_DIR/netobserv-dittybopper.yaml.template >$SCRIPTS_DIR/netobserv-dittybopper.yaml
-}
-
 deploy_lokistack() {
+  echo "====> Deploying LokiStack"
+  echo "====> Creating openshift-operators-redhat Namespace and OperatorGroup, loki-operator Subscription"
   oc apply -f $SCRIPTS_DIR/loki-subscription.yaml -n openshift-operators-redhat
   sleep 30
   RAND_SUFFIX=$(tr </dev/urandom -dc 'a-z0-9' | fold -w 12 | head -n 1 || true)
@@ -91,13 +62,17 @@ deploy_lokistack() {
     export S3_BUCKETNAME="netobserv-ocpqe-perf-loki-$WORKLOAD"
   fi
 
+  # if cluster is to be preserved, do the same for S3 bucket
   if [[ ${CLUSTER_NAME} =~ "preserve" ]]; then
     S3_BUCKETNAME+="-preserve"
   fi
+  echo "====> S3_BUCKETNAME is $S3_BUCKETNAME"
 
-  # create s3 secret for loki
+  echo "====> Creating S3 secret for Loki"
   $SCRIPTS_DIR/deploy-loki-aws-secret.sh $S3_BUCKETNAME
   oc wait --timeout=180s --for=condition=ready pod -l app.kubernetes.io/name=loki-operator -n openshift-operators-redhat
+  
+  echo "====> Determining LokiStack config"
   if [[ "${LOKISTACK_SIZE}" == "1x.extra-small" ]]; then
     LokiStack_CONFIG=$SCRIPTS_DIR/lokistack-1x-exsmall.yaml
   elif [[ "${LOKISTACK_SIZE}" == "1x.small" ]]; then
@@ -109,19 +84,46 @@ deploy_lokistack() {
   fi
   TMP_LOKICONFIG=/tmp/lokiconfig.yaml
   envsubst <$LokiStack_CONFIG >$TMP_LOKICONFIG
+
+  echo "====> Creating LokiStack"
   oc apply -f $TMP_LOKICONFIG
   sleep 30
   oc wait --timeout=300s --for=condition=ready pod -l app.kubernetes.io/name=lokistack -n openshift-operators-redhat
 }
 
+deploy_loki() {
+  echo "====> Deploying Loki"
+  oc apply -f $SCRIPTS_DIR/loki-storage-1.yaml
+  oc apply -f $SCRIPTS_DIR/loki-storage-2.yaml
+  oc wait --timeout=120s --for=condition=ready pod -l app=loki -n ${NAMESPACE}
+}
+
+populate_netobserv_metrics() {
+  echo "====> Creating cluster-monitoring-config ConfigMap"
+  oc apply -f $SCRIPTS_DIR/cluster-monitoring-config.yaml
+  DEPLOYMENT_MODEL=$(oc get flowcollector -o jsonpath="{.items[*].spec.deploymentModel}" -n netobserv)
+  if [[ $DEPLOYMENT_MODEL == "KAFKA" ]]; then
+    echo "====> Creating flowlogs-pipeline-transformer Service and ServiceMonitor"
+    oc apply -f $SCRIPTS_DIR/service-monitor-kafka.yaml
+  else
+    echo "====> Creating flowlogs-pipeline Service and ServiceMonitor"
+    oc apply -f $SCRIPTS_DIR/service-monitor.yaml
+  fi
+}
+
 deploy_kafka() {
+  echo "====> Deploying Kafka"
   oc create namespace ${NAMESPACE} --dry-run=client -o yaml | oc apply -f -
+  echo "====> Creating amq-streams Subscription"
   oc apply -f $SCRIPTS_DIR/amq-streams/subscription.yaml
   sleep 60
   oc wait --timeout=180s --for=condition=ready pod -l name=amq-streams-cluster-operator -n openshift-operators
+  echo "====> Creating kafka-metrics ConfigMap and kafka-resources-metrics PodMonitor"
   oc apply -f "https://raw.githubusercontent.com/netobserv/documents/main/examples/kafka/metrics-config.yaml" -n ${NAMESPACE}
+  echo "====> Creating Kafka"
   curl -s -L "https://raw.githubusercontent.com/netobserv/documents/main/examples/kafka/default.yaml" | envsubst | oc apply -n ${NAMESPACE} -f -
 
+  echo "====> Creating network-flows KafkaTopic"
   KAFKA_TOPIC=$SCRIPTS_DIR/amq-streams/kafkaTopic.yaml
   TMP_KAFKA_TOPIC=/tmp/topic.yaml
   envsubst <$KAFKA_TOPIC >$TMP_KAFKA_TOPIC
@@ -129,12 +131,63 @@ deploy_kafka() {
   sleep 60
   oc wait --timeout=180s --for=condition=ready kafkatopic network-flows -n ${NAMESPACE}
 
+  echo "====> Update flowcollector to use KAFKA deploymentModel"
   oc patch flowcollector cluster --type=json -p "[{"op": "replace", "path": "/spec/deploymentModel", "value": "KAFKA"}]"
 
-  # updated FLP replicas # if different than already configured.
-  FLP_REPLICAS=$(oc get flowcollector/cluster -o jsonpath='{.spec.processor.kafkaConsumerReplicas}')
-  if [[ "$FLP_KAFKA_REPLICAS" != "$FLP_REPLICAS" ]]; then
-    oc patch flowcollector/cluster --type=json -p "[{"op": "replace", "path": "/spec/processor/kafkaConsumerReplicas", "value": ${FLP_KAFKA_REPLICAS}}]"
-  fi
+  echo "====> Update flowcollector replicas"
+  oc patch flowcollector/cluster --type=json -p "[{"op": "replace", "path": "/spec/processor/kafkaConsumerReplicas", "value": ${FLP_KAFKA_REPLICAS}}]"
+
   oc wait --timeout=180s --for=condition=ready flowcollector/cluster
+}
+
+setup_dittybopper_template() {
+  echo "====> Setting up dittybopper template"
+  sleep 30
+  oc wait --timeout=120s --for=condition=ready pod -n openshift-user-workload-monitoring -l app.kubernetes.io/component=controller
+  oc wait --timeout=120s --for=condition=ready pod -n openshift-user-workload-monitoring -l app.kubernetes.io/managed-by=prometheus-operator
+  export PROMETHEUS_USER_WORKLOAD_BEARER=$(oc sa get-token prometheus-user-workload -n openshift-user-workload-monitoring || oc sa new-token prometheus-user-workload -n openshift-user-workload-monitoring)
+  export THANOS_URL=https://$(oc get route thanos-querier -n openshift-monitoring -o json | jq -r '.spec.host')
+  envsubst "${PROMETHEUS_USER_WORKLOAD_BEARER} ${THANOS_URL}" <$SCRIPTS_DIR/netobserv-dittybopper.yaml.template >$SCRIPTS_DIR/netobserv-dittybopper.yaml
+}
+
+delete_s3() {
+  echo "====> Deleting AWS S3 Bucket, LokiStack, flowcollector, and Kafka (if applicable)"
+  echo "====> Getting S3 Bucket Name"
+  S3_BUCKET_NAME=$(/bin/bash -c 'oc extract cm/lokistack-config -n openshift-operators-redhat --keys=config.yaml --confirm --to=/tmp | xargs -I {} egrep bucketnames {} | cut -d: -f 2 | xargs echo -n')
+  echo "====> Got $S3_BUCKET_NAME"
+  aws s3 rm s3://$S3_BUCKET_NAME --recursive
+  aws s3 rb s3://$S3_BUCKET_NAME --force
+  oc delete lokistack/lokistack -n openshift-operators-redhat
+  delete_flowcollector
+  echo "====> Getting Deployment Model"
+  DEPLOYMENT_MODEL=$(oc get flowcollector -o jsonpath="{.items[*].spec.deploymentModel}" -n netobserv)
+  echo "====> Got $DEPLOYMENT_MODEL"
+  if [[ $DEPLOYMENT_MODEL == "KAFKA" ]]; then
+      oc delete kafka/kafka-cluster -n netobserv
+      oc delete kafkaTopic/network-flows -n netobserv
+  fi
+}
+
+uninstall_netobserv() {
+  echo "====> Uninstalling NetObserv"
+  delete_flowcollector
+  echo "====> Deleting NetObserv Subscription, OperatorGroup, and Project"
+  oc delete --ignore-not-found -f $SCRIPTS_DIR/noo-main-subscription.yaml
+  oc delete --ignore-not-found -f $SCRIPTS_DIR/noo-released-subscription.yaml
+  oc delete csv -l operators.coreos.com/netobserv-operator.${NAMESPACE}
+  oc delete -f $SCRIPTS_DIR/operator_group.yaml
+  oc delete project ${NAMESPACE}
+  echo "====> Deleting netobserv-testing CatalogSource"
+  oc delete --ignore-not-found catalogsource/netobserv-testing -n openshift-marketplace
+}
+
+delete_flowcollector() {
+  echo "====> Deleting flowcollector"
+  oc delete --ignore-not-found flowcollector/cluster
+}
+
+nukeobserv() {
+  echo "====> Nuking NetObserv and all related resources"
+  delete_s3
+  uninstall_netobserv
 }

--- a/scripts/nope.py
+++ b/scripts/nope.py
@@ -415,8 +415,8 @@ if __name__ == '__main__':
         logging.error("START_TIME and END_TIME are needed to proceed")
         sys.exit(1)
     else:
-        logging.info("Parsed Start Time: " + datetime.datetime.fromtimestamp(int(START_TIME)).strftime('%I:%M%p%Z UTC on %m/%d/%Y'))
-        logging.info("Parsed End Time:   " + datetime.datetime.fromtimestamp(int(END_TIME)).strftime('%I:%M%p%Z UTC on %m/%d/%Y'))
+        logging.info("Parsed Start Time: " + datetime.datetime.utcfromtimestamp(int(START_TIME)).strftime('%I:%M%p%Z UTC on %m/%d/%Y'))
+        logging.info("Parsed End Time:   " + datetime.datetime.utcfromtimestamp(int(END_TIME)).strftime('%I:%M%p%Z UTC on %m/%d/%Y'))
         logging.info("Step is:           " + STEP)
 
     # check if Jenkins arguments are valid and if so set constants

--- a/scripts/uperf_env.sh
+++ b/scripts/uperf_env.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 export UUID=$(uuidgen | tr "[:upper:]" "[:lower:]")
 export server=$(oc get nodes -l "node-role.kubernetes.io/worker" -o custom-columns=NAME:".metadata.name" --no-headers | head -1)
 export client=$(oc get nodes -l "node-role.kubernetes.io/worker" -o custom-columns=NAME:".metadata.name" --no-headers | tail -1)


### PR DESCRIPTION
This PR makes the following changes:
- Simplifies Jenkinsfile with additional template directions and scripting moved to the shell scripts
- Removed need for `$WORKSPACE` variable if running `netobserv.sh` scripts locally
- Updated shell scripts with additional logging and minor functionality changes
- Added `nukeobserv` function to completely remove all NetObserv artifacts from a cluster
- Updated CRDs by changing `cacheMaxFlows` value for eBFP
- `uninstall_netobserv` no longer requires `INSTALLATION_SOURCE` to be set
- Switched `Setup FLP service and service-monitor` and `Configure flowcollector and Kafka` Jenkins stage positions and names
- Minor fix to NOPE tool