### PR TITLE
Adding parallel runs of kraken,cerberus,upgrade(if set)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,260 @@
+@Library('flexy') _
+
+// rename build
+def userId = currentBuild.rawBuild.getCause(hudson.model.Cause$UserIdCause)?.userId
+if (userId) {
+  currentBuild.displayName = userId
+}
+
+def RETURNSTATUS = "default"
+def output = ""
+
+def kraken_job = ""
+def cerberus_job = ""
+def upgrade_ci = ""
+
+pipeline {
+  agent none
+  parameters {
+        string(
+          name: 'BUILD_NUMBER', 
+          defaultValue: '', 
+          description: 'Build number of job that has installed the cluster.'
+        )
+        string(
+          name: 'UPGRADE_VERSION', 
+          description: 'This variable sets the version number you want to upgrade your OpenShift cluster to.'
+        )
+        booleanParam(
+          name: 'ENABLE_FORCE', 
+          defaultValue: true, 
+          description: 'This variable will force the upgrade or not'
+        )
+        string(
+          name: 'MAX_UNAVAILABLE', 
+          defaultValue: "1",
+          description: 'This variable will set the max number of unavailable nodes during the upgrade'
+        )
+        string(
+            name: "CERBERUS_WATCH_NAMESPACES", 
+            defaultValue: "[^.*\$]",
+            description: "Which specific namespaces you want to watch any failing components, use [^.*\$] if you want to watch all namespaces"
+        )
+        string(
+            name: "CERBERUS_IGNORE_PODS",
+            defaultValue: "[^installer*, ^kube-burner*, ^redhat-operators*, ^certified-operators*]", 
+            description: "Which specific pod names regex patterns you want to ignore in the namespaces you defined above"
+        )
+        string(
+            name: 'CERBERUS_ITERATIONS', 
+            defaultValue: '', 
+            description: 'Number of iterations to run of cerberus.'
+        )
+        string(
+          name: "PAUSE_TIME",
+          defaultValue: "100",
+          description: 'Amount of time to pause before running chaos scenarios'
+        )
+        choice(
+          choices: ["application-outages","container-scenarios","namespace-scenarios","network-scenarios","node-scenarios","pod-scenarios","node-cpu-hog","node-io-hog", "node-memory-hog", "power-outages","pvc-scenario","time-scenarios","zone-outages"], 
+          name: 'KRAKEN_SCENARIO', 
+          description: '''Type of kraken scenario to run'''
+        )
+        choice(
+          choices: ["python","pod"], 
+          name: 'KRAKEN_RUN_TYPE', 
+          description: '''Type of way to run chaos scenario'''
+        )
+        string(
+            name: 'ITERATIONS', 
+            defaultValue: '', 
+            description: 'Number of iterations to run of kraken scenario.'
+        )
+        string(
+          name:'JENKINS_AGENT_LABEL',
+          defaultValue:'oc412',
+          description:
+            '''
+            scale-ci-static: for static agent that is specific to scale-ci, useful when the jenkins dynamic agent isn't stable<br>
+            4.y: oc4y || mac-installer || rhel8-installer-4y <br/>
+                e.g, for 4.8, use oc48 || mac-installer || rhel8-installer-48 <br/>
+            3.11: ansible-2.6 <br/>
+            3.9~3.10: ansible-2.4 <br/>
+            3.4~3.7: ansible-2.4-extra || ansible-2.3 <br/>
+            '''
+        )
+       text(
+        name: 'ENV_VARS', 
+        defaultValue: '',
+        description:'''<p>
+               Enter list of additional (optional) Env Vars you'd want to pass to the script, one pair on each line. <br>
+               See https://github.com/redhat-chaos/krkn-hub/blob/main/docs/cerberus.md for list of variables to pass <br>
+               e.g.<br>
+               SOMEVAR1='env-test'<br>
+               SOMEVAR2='env2-test'<br>
+               ...<br>
+               SOMEVARn='envn-test'<br>
+               </p>'''
+        )
+        string(
+            name: 'CERBERUS_REPO',
+            defaultValue: 'https://github.com/redhat-chaos/cerberus',
+            description: 'You can change this to point to your fork if needed.'
+        )
+        string(
+            name: 'CERBERUS_REPO_BRANCH',
+            defaultValue: 'main', 
+            description: 'You can change this to point to a branch on your fork if needed.'
+        )
+       string(
+        name: 'KRAKEN_REPO', 
+        defaultValue:'https://github.com/redhat-chaos/krkn', 
+        description:'You can change this to point to your fork if needed.'
+       )
+       string(
+        name: 'KRAKN_REPO_BRANCH', 
+        defaultValue:'main', 
+        description:'You can change this to point to a branch on your fork if needed.'
+       )
+       string(
+        name: 'KRAKEN_HUB_REPO', 
+        defaultValue:'https://github.com/redhat-chaos/krkn-hub', 
+        description:'You can change this to point to your fork if needed.'
+        )
+       string(
+        name: 'KRAKN_HUB_REPO_BRANCH', 
+        defaultValue:'main', 
+        description:'You can change this to point to a branch on your fork if needed.'
+      )
+     }
+
+  stages {
+    stage("Set base variables") { 
+        agent { label params['JENKINS_AGENT_LABEL'] }
+            steps {
+                script {
+
+                  if ( UPGRADE_VERSION == "" ) {
+                    currentBuild.description = """
+                      Running kraken and cerberus in parallel<br>
+                    """
+                  } else {
+                    currentBuild.description = """
+                      Running kraken during an upgrade and cerberus all in parallel <br>
+                    """
+                  }
+                }
+      }
+    }
+    stage("Run parallel tests") {
+    parallel {
+      stage("Check cluster health") {
+          agent { label params['JENKINS_AGENT_LABEL'] }
+          steps {
+              script {
+                  cerberus_job = build job: 'scale-ci/e2e-benchmarking-multibranch-pipeline/cerberus',
+                      parameters: [
+                          string(name: 'BUILD_NUMBER', value: BUILD_NUMBER),text(name: "ENV_VARS", value: ENV_VARS),
+                          string(name: "CERBERUS_WATCH_NAMESPACES", value: CERBERUS_WATCH_NAMESPACES),
+                          string(name: 'CERBERUS_IGNORE_PODS', value: CERBERUS_IGNORE_PODS),string(name: 'CERBERUS_ITERATIONS', value: CERBERUS_ITERATIONS),
+                          string(name: 'JENKINS_AGENT_LABEL', value: JENKINS_AGENT_LABEL),booleanParam(name: "INSPECT_COMPONENTS", value: false),
+                          string(name: "ENV_VARS", value: ENV_VARS)
+                      ],
+                      propagate: false
+                  currentBuild.description += """
+                      <b>Cerberus Job: </b> <a href="${cerberus_job.absoluteUrl}"> ${params.CERBERUS_ITERATIONS} iterations were ran</a> <br/>
+                  """
+              }
+          }
+        }
+      stage("Start Kraken run") {
+          agent { label params['JENKINS_AGENT_LABEL'] }
+          steps {
+              script {
+                    kraken_job = build job: 'scale-ci/e2e-benchmarking-multibranch-pipeline/kraken',
+                      parameters: [
+                          string(name: 'BUILD_NUMBER', value: BUILD_NUMBER),text(name: "ENV_VARS", value: ENV_VARS),
+                          string(name: "KRAKEN_REPO", value: KRAKEN_REPO),string(name: "KRAKN_REPO_BRANCH", value: KRAKN_REPO_BRANCH),
+                          string(name: "KRAKEN_HUB_REPO", value: KRAKEN_HUB_REPO),string(name: "KRAKN_HUB_REPO_BRANCH", value: KRAKN_HUB_REPO_BRANCH),
+                          string(name: 'KRAKEN_SCENARIO', value: KRAKEN_SCENARIO),string(name: "KRAKEN_RUN_TYPE", value: KRAKEN_RUN_TYPE),
+                          string(name: 'JENKINS_AGENT_LABEL', value: JENKINS_AGENT_LABEL),string(name: "PAUSE_TIME", value: PAUSE_TIME),
+                          string(name: "ITERATIONS", value: ITERATIONS),string(name: "ENV_VARS", value: ENV_VARS)
+                      ],
+                      propagate: false
+                    currentBuild.description += """
+                      <b>Kraken Job: </b> <a href="${kraken_job.absoluteUrl}"> ${KRAKEN_SCENARIO} </a> <br/>
+                  """
+              }
+          }
+        }
+      stage('Upgrade'){
+          agent { label params['JENKINS_AGENT_LABEL'] }
+          when {
+              expression { UPGRADE_VERSION != "" }
+          }
+          steps{
+              script{
+                  currentBuild.description += """
+                      <b>Upgrade to: </b> ${UPGRADE_VERSION} <br/>
+                  """
+                  upgrade_ci = build job: "scale-ci/e2e-benchmarking-multibranch-pipeline/upgrade", propagate: false,parameters:[
+                      string(name: "BUILD_NUMBER", value: BUILD_NUMBER),string(name: "MAX_UNAVAILABLE", value: MAX_UNAVAILABLE),
+                      string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL),string(name: "UPGRADE_VERSION", value: UPGRADE_VERSION),
+                      booleanParam(name: "ENABLE_FORCE", value: ENABLE_FORCE),booleanParam(name: "WRITE_TO_FILE", value: false),
+                      text(name: "ENV_VARS", value: ENV_VARS)
+                  ]
+                  currentBuild.description += """
+                      <b>Upgrade Job: </b> <a href="${upgrade_ci.absoluteUrl}"> ${upgrade_ci.getNumber()} </a> <br/>
+                  """
+                  
+              }
+          }
+      }
+    }
+    }
+  stage('Set status') {
+    agent { label params['JENKINS_AGENT_LABEL'] }
+    steps {
+      script{
+        def status = ""
+        if ( upgrade_ci != "" ) {
+          if ( upgrade_ci.result.toString() != "SUCCESS" ) { 
+            status += "Upgrade Failed"
+            currentBuild.result = "FAILURE"
+          } else { 
+            status += "Upgrade Passed"
+          }
+        }
+        if ( kraken_job != "" ) {
+          if (status != "" ) {
+              status += ","
+            }
+          if ( kraken_job.result.toString() != "SUCCESS" ){
+              status += "Kraken Failed"
+              currentBuild.result = "FAILURE"
+          } else { 
+            status += "Kraken Passed"
+          }
+        }
+        if ( cerberus_job != "" ) {
+          if (status != "" ) {
+              status += ","
+            }
+          if ( cerberus_job.result.toString() != "SUCCESS" ) {
+            if (status != "" ) {
+              status += ","
+            }
+              status += "Cerberus Failed"
+              currentBuild.result = "FAILURE"
+          } else { 
+            status += "Cerberus Passed"
+          }
+        }
+        currentBuild.description += """
+            <b>Final Status: </b> ${status} <br/>
+        """
+        }
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,24 +1,60 @@
-# ocp-qe-perfscale-ci
+# Chaos During Upgrade while Monitoring Cluster
+
+This jenkinsfile tests the clusters ability to withstand chaotic scenarios during an upgrade and show it's recovery and overall cluster health once complete.
+
+Right now you have to set a hard coded number of iterations for cerberus to run, haven't figured out how to stop dameon mode once it starts 
+
+The cerberus job, kraken and upgrade (if upstream version set) are all run in parallel and will wait for all jobs to fully finish before ending the test
 
 
-## Purpose
+## Cerberus
 
-This repo would contain `Jenkinsfile` and any other pertaining contents that would be used by a multi-branch pipeline in our Jenkins.
+For full information see [cerberus github](https://github.com/redhat-chaos/cerberus)
 
-## Structure
+## Kraken
 
-There are multiple orphan branches present in this repos, each of them are supposed to house one kind of workload for [E2E-benchmarking](https://github.com/cloud-bulldozer/e2e-benchmarking/). Each branch should contain one `Jenkinsfile`
+For full information see [kraken github](https://github.com/redhat-chaos/krkn)
 
-You can create a new orphan branch simply by `git checkout --orphan BRANCHNAME` for new workload.
 
-Jenkins multi-branch pipeline job will look at the `Jenkinsfile` on each of these branches and create a new workload job for you to execute in your Jenkins.
+### Configurations 
 
-This repository also hosting the `perf-dashboard-grafana-crs` directory, that includes all the Custom Resources and relevant files that you need to deploy a fully functional perf-scale dashboard.
-This deployment uses grafana operator to enable grafana operator on your cluster, create an instance, create required datasources(in this case Prometheus and ElasticSearch) and dashboards.
+BUILD_NUMBER: Only accepts flexy built clusters, pass the flexy id number 
 
-See `launch-grafana.sh` for env variables we need. And, `cleanup-grafana.sh` could be used to cleanup everything created by the `launch-grafana.sh` script.
+UPGRADE_VERSION: what version you want your cluster to upgrade to, if set to blank won't upgrade at all 
 
-**PREREQUISITE:** is to have `KUBECONFIG` env variable configured that can access your OpenShift cluster. 
+Number of iterations to run cerberus: CERBERUS_ITERATIONS
 
-### Author
-Kedar Kulkarni <@kedark3 on Github>
+To watch all created namespaces set the following variable CERBERUS_WATCH_NAMESPACES = [^.*\$]
+
+Set the type of chaos scenario to run by using KRAKEN_SCENARIO
+
+Scenario types are: 
+* application-outages
+* container-scenarios
+* namespace-scenarios
+* network-scenarios
+* pod-scenarios
+* node-cpu-hog
+* node-io-hog
+* node-memory-hog
+* power-outages
+* pvc-scenario
+* time-scenarios
+* zone-outages
+
+There are 2 ways to the run the chaos scenario on a cluster: using **python** or running kraken in a **pod** on your cluster. Set using KRAKEN_RUN_TYPE
+
+ENV_VARS: be able to set any of the parameters in each of the above scenarios seperate than the defaults defined in each of the env.sh files in the folder of the scenario in kraken-hub
+See all environment variables [here](https://github.com/redhat-chaos/krkn-hub/blob/main/docs/all_scenarios_env.md) and look at [cerberus](https://github.com/redhat-chaos/krkn-hub/blob/main/docs/cerberus.md) and the specific kraken scenario you're running docs as well 
+
+KRAKEN_REPO: what is the url of kraken you want to use
+
+KRAKN_REPO_BRANCH: branch of the kraken repo you set above to run (helpful with testing changes)
+
+KRAKEN_HUB_REPO: what is the url of kraken-hub you want to use, useful when setting env vars changes
+
+KRAKN_HUB_REPO_BRANCH: what is the branch of kraken-hub you want to use; again, useful when setting env vars changes
+
+CERBERUS_REPO: what is the url of cerberus you want to use
+
+CERBERUS_REPO_BRANCH: branch of the cerberus repo you set above to run (helpful with testing cerberus changes)


### PR DESCRIPTION
Adding job to be able to run cerberus, kraken and an upgrade in parallel 

https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/paige-e2e-multibranch/job/chaos_upgrade/41/console 
(failure only because I had to abort Cerberus b/c I gave too many iterations) 

Currently have to hard code number of iterations for cerberus to run. Each iteration (with the 3 second wait) takes between 7-10 seconds and an upgrade takes any where from 1.2 -3 hours. 
Note: For an upgrade that latest 1.2 hours I ran about 500 iterations in the same time 