### PR TITLE
Kube burner with QE es server

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -262,7 +262,8 @@ pipeline {
                 else {
                     env.EMAIL_ID_FOR_RESULTS_SHEET = "${userId}@redhat.com"
                 }
-                withCredentials([file(credentialsId: 'sa-google-sheet', variable: 'GSHEET_KEY_LOCATION')]) {
+                withCredentials([usernamePassword(credentialsId: 'elasticsearch-perfscale-ocp-qe', usernameVariable: 'ES_USERNAME', passwordVariable: 'ES_PASSWORD'),
+                    file(credentialsId: 'sa-google-sheet', variable: 'GSHEET_KEY_LOCATION')]) {
                     RETURNSTATUS = sh(returnStatus: true, script: '''
                         # Get ENV VARS Supplied by the user to this job and store in .env_override
                         echo "$ENV_VARS" > .env_override
@@ -271,7 +272,7 @@ pipeline {
                         cp $GSHEET_KEY_LOCATION $WORKSPACE/.gsheet.json
                         export GSHEET_KEY_LOCATION=$WORKSPACE/.gsheet.json
                         export EMAIL_ID_FOR_RESULTS_SHEET=$EMAIL_ID_FOR_RESULTS_SHEET
-
+                        export ES_SERVER="https://$ES_USERNAME:$ES_PASSWORD@search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com"
                         mkdir -p ~/.kube
                         cp $WORKSPACE/flexy-artifacts/workdir/install-dir/auth/kubeconfig ~/.kube/config
                         ls -ls ~/.kube/


### PR DESCRIPTION
Adding QE es server set up to kube-burner job to keep our own history 

Need to update write to script to properly get new grafana link 

Passing job: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/paige-e2e-multibranch/job/kube-burner/168/console

https://search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com/_plugin/kibana/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1h,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'0af29050-07fa-11ec-97a8-03ce3777b5a2',key:uuid,negate:!f,params:(query:a3b8dc37-6675-42f9-9e3b-885b3da3ba6c),type:phrase),query:(match_phrase:(uuid:a3b8dc37-6675-42f9-9e3b-885b3da3ba6c)))),index:'0af29050-07fa-11ec-97a8-03ce3777b5a2',interval:auto,query:(language:kuery,query:''),sort:!())