### PR TITLE
adding pod latencies to new es server

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,7 +79,8 @@ pipeline {
           buildinfo.params.each { env.setProperty(it.key, it.value) }
         }
         ansiColor('xterm') {
-          withCredentials([file(credentialsId: 'sa-google-sheet', variable: 'GSHEET_KEY_LOCATION')]) {
+          withCredentials([usernamePassword(credentialsId: 'elasticsearch-perfscale-ocp-qe', usernameVariable: 'ES_USERNAME', passwordVariable: 'ES_PASSWORD'),
+            file(credentialsId: 'sa-google-sheet', variable: 'GSHEET_KEY_LOCATION')]) {
             sh label: '', script: """
             # Get ENV VARS Supplied by the user to this job and store in .env_override
             echo "$ENV_VARS" > .env_override
@@ -110,7 +111,7 @@ pipeline {
             else
                 echo "else job"
                 printf '${params.JOB_OUTPUT}' >> output_file.out
-                python -c "import write_scale_results_sheet; write_scale_results_sheet.write_to_sheet('$GSHEET_KEY_LOCATION', ${params.BUILD_NUMBER},  '${params.CI_JOB_ID}', '${params.JOB}', '${params.CI_JOB_URL}', '${params.CI_STATUS}', '${params.JOB_PARAMETERS}', 'output_file.out', 'env_vars.out', '${params.USER}')"
+                python -c "import write_scale_results_sheet; write_scale_results_sheet.write_to_sheet('$GSHEET_KEY_LOCATION', ${params.BUILD_NUMBER},  '${params.CI_JOB_ID}', '${params.JOB}', '${params.CI_JOB_URL}', '${params.CI_STATUS}', '${params.JOB_PARAMETERS}', 'output_file.out', 'env_vars.out', '${params.USER}', '$ES_USERNAME', '$ES_PASSWORD')"
             fi
             rm -rf ~/.kube
             """

--- a/write_to_sheet/write_helper.py
+++ b/write_to_sheet/write_helper.py
@@ -52,10 +52,10 @@ def get_upgrade_duration():
         return str(time_elapsed), all_versions
     return get_oc_version(), ""
 
-def get_pod_latencies(uuid="",creation_time=""):
+def get_pod_latencies(uuid="",creation_time="",es_username="", es_password=""):
     if uuid != "":
         # In the form of [[json_data['quantileName'], json_data['avg'], json_data['P99']...]
-        pod_latencies_list = get_es_data.get_pod_latency_data(uuid, creation_time)
+        pod_latencies_list = get_es_data.get_pod_latency_data(uuid, creation_time,es_username,es_password)
         if len(pod_latencies_list) != 0:
             avg_list = []
             p99_list = []


### PR DESCRIPTION
With the switch to the new qe elastic server, we were not properly curling the right server when printing the results to the google sheet. 

https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/paige-e2e-multibranch/job/qe_es_grafana/10/console

See cluster density with "test" and 4 parameters with pod latencies 
