### PR TITLE
Upgrade updates for EUS and 4.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ WRITE_TO_FILE: Boolean on whether to write results to Upgrade tab in Scale-Ci sh
 
 
 ### EUS Upgarde General Information
-For EUS_UPGRADE and arm architecture types, will get versions from here
+
+Arm architecture types, will get versions from here
 https://arm64.ocp.releases.ci.openshift.org/graph
 
 If non arm type, will use 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ WRITE_TO_FILE: Boolean on whether to write results to Upgrade tab in Scale-Ci sh
 
 
 ### EUS Upgarde General Information
-
-Arm architecture types, will get versions from here
+For EUS_UPGRADE and arm architecture types, will get versions from here
 https://arm64.ocp.releases.ci.openshift.org/graph
 
 If non arm type, will use 

--- a/upgrade_scripts/check_upgrade.py
+++ b/upgrade_scripts/check_upgrade.py
@@ -37,6 +37,8 @@ def set_upstream_channel(channel, version):
     print('small v ' + str(small_version))
     if small_version == "4.9":
         patch_48_to_49()
+    if small_version == "4.12":
+        patch_411_to_412()
     merge_json = '{"spec":{"channel": "%s-%s" }}' % (channel, small_version)
     return_code, output = invoke(f"oc patch clusterversion/version --type='merge' -p='{merge_json}'")
     if return_code != 0:
@@ -50,6 +52,13 @@ def patch_48_to_49():
     print('patch api')
     return_code, output = invoke(f"oc -n openshift-config patch cm admin-acks --type=merge -p='{merge_json}'")
     print('output: ' + str(output))
+
+def patch_411_to_412(): 
+    merge_json = '{"data":{"ack-4.11-kube-1.25-api-removals-in-4.12":"true"}}'
+    print('patch api')
+    return_code, output = invoke(f"oc -n openshift-config patch cm admin-acks --type=merge -p='{merge_json}'")
+    print('output: ' + str(output))
+
 
 def set_upstream_url(url):
 

--- a/upgrade_scripts/check_upgrade.py
+++ b/upgrade_scripts/check_upgrade.py
@@ -78,10 +78,12 @@ def verify_version_in_channel_list(expected_version):
 def get_upgrade_status(mcp_json):
     for mcp_status in mcp_json['status']['conditions']:
         if mcp_status['type'] == "Updating":
+            print('Upgrade mcp status: ' + str(mcp_status['status']))
             return mcp_status['status']
 
 def wait_for_mcp_upgrade(wait_num=90):
     counter = 0
+    time.sleep(20)
     return_code, worker_str = invoke(f"oc get mcp worker -o json")
     worker_json = json.loads(worker_str)
     while get_upgrade_status(worker_json) != "False":

--- a/upgrade_scripts/upgrade.sh
+++ b/upgrade_scripts/upgrade.sh
@@ -140,22 +140,9 @@ function abnormal_co() {
       echo -e "post check passed without err.\n"
 
   else
-      echo -e "upgrade post check find err, collect must-gather....\n"
-      schedulable_masters=(`oc get node | grep master |egrep -v 'Ready,SchedulingDisabled|NotReady'|awk '{print $1'}`)
-      if [ -z "$schedulable_masters" ]; then
-          echo "Skipping must-gather as there are no schedulable masters...\n"
-      else
-          oc adm must-gather --node-name=${schedulable_masters[0]}>/dev/null 2>&1
-          ls must-gather.local*
-          if [ $? -eq 0 ]; then
-              filename=`ls |grep must-gather.local*`
-              tar -czvf must-gather.tar.gz $filename >/dev/null 2>&1
-              ls
-          else
-             echo -e "must-gather file creation fails!!!"
-          fi
-      fi
       python3 -c "import check_upgrade; check_upgrade.pause_machinepool_worker('false')"
+      sleep 10
+      python3 -c "import check_upgrade; check_upgrade.wait_for_mcp_upgrade()"
       exit 127 # upgrade itself succ and post-check fail
   fi
 


### PR DESCRIPTION
When trying to upgrade to 4.12 with EUS type, got an error only on the console giving documentation link: https://access.redhat.com/articles/6955381
Adding the command in the documentation when doing 4.11->4.12 upgrades 

After pr gets merged, wanting to take advantage of the new must gather job for collecting data about a cluster
https://github.com/openshift-qe/ocp-qe-perfscale-ci/pull/353/files