### PR TITLE
Adding jq instllation for pypi and aptget

### DIFF
--- a/prow/Dockerfile
+++ b/prow/Dockerfile
@@ -2,4 +2,6 @@ FROM quay.io/openshifttest/python:3.9
 
 LABEL vendor="Red Hat Inc." maintainer="OCP QE Team"
 
-RUN curl -sSL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz | tar -xvzf -  &&  mv oc /bin && mv kubectl /bin && apt-get update && apt-get install gettext-base && apt-get install uuid-runtime && ln -s /bin/bash /usr/bin/bash && /usr/local/bin/python -m pip install --upgrade pip && pip install virtualenv
+RUN curl -sSL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz | tar -xvzf -  &&\
+    mv oc /bin && mv kubectl /bin && apt-get update && apt-get install -y gettext-base uuid-runtime jq && \
+    ln -s /bin/bash /usr/bin/bash && /usr/local/bin/python -m pip install --upgrade pip && pip install virtualenv jq


### PR DESCRIPTION
Adding jq option on system for OCP-QE-Perfscale tests in prow 

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/36227/rehearse-36227-periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-ocp-qe-perfscale-ci-tests/1623714904819109888

```
time="2023-02-09 18:08:27" level=info msg="Finished the create job in 1h0m35s"
time="2023-02-09 18:08:27" level=info msg="Verifying created objects"
time="2023-02-09 18:08:27" level=info msg="pods found: 674 Expected: 674"
time="2023-02-09 18:08:27" level=info msg="Stopping measurement: podLatency"
time="2023-02-09 18:08:27" level=info msg="Evaluating latency thresholds"
time="2023-02-09 18:08:27" level=error msg="❗ P99 Ready latency (965.74s) higher than configured threshold: 2m0s"
time="2023-02-09 18:08:29" level=info msg="node-density: PodScheduled 50th: 63 99th: 487 max: 3859 avg: 97"
time="2023-02-09 18:08:29" level=info msg="node-density: ContainersReady 50th: 44606 99th: 965739 max: 2523235 avg: 112200"
time="2023-02-09 18:08:29" level=info msg="node-density: Initialized 50th: 4976 99th: 14663 max: 17802 avg: 5743"
time="2023-02-09 18:08:29" level=info msg="node-density: Ready 50th: 44606 99th: 965739 max: 2523235 avg: 112200"
time="2023-02-09 18:08:29" level=info msg="Job node-density took 3637.33 seconds"
7 skipped lines...
../../utils/common.sh: line 136: jq: command not found
../../utils/common.sh: line 137: jq: command not found
../../utils/common.sh: line 138: jq: command not found
```