### PR TITLE
Getting abnormal cluster operators with jsonpath

### DIFF
--- a/upgrade_scripts/upgrade.sh
+++ b/upgrade_scripts/upgrade.sh
@@ -120,8 +120,8 @@ function abnormal_co() {
   fi 
 
   echo -e "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~Abnormal co details~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n\n"
-  bnormalCO=""
-  abnormalCO=$(oc get co |sed '1d'|grep -v "openshift-samples"|grep -v '.*True.*False.*False' | awk '{print $1}')
+  abnormalCO=""
+  abnormalCO=$(oc get co -o jsonpath='{range .items[*]}{.metadata.name} {range .status.conditions[*]} {.type}={.status}{end}{"\n"}{end}' | grep -v "openshift-samples" | grep -w -E 'Available=False|Progressing=True|Degraded=True' | awk '{print $1}')
   if [ "X$abnormaalCO" != "X" ]; then
       upgrade_pass=False
       quick_diagnosis "$abnormalCO"


### PR DESCRIPTION
Old good grep was not precise in some cases:
Ex. 
`echo -e 'a\tTrue\tFalse\tFalse\tsome comment\nb\tTrue\tTrue\tFalse\tsome other comment\nc\tTrue\tFalse\tTrue\tsome comment with False in'`

```
a	True	False	False	some comment
b	True	True	False	some other comment
c	True	False	True	some comment with False in
```

Using with grep 
`echo -e 'a\tTrue\tFalse\tFalse\tsome comment\nb\tTrue\tTrue\tFalse\tsome other comment\nc\tTrue\tFalse\tTrue\tsome comment with False in' | grep -v '.*True.*False.*False`

`b	True	True	False	some other comment`

was missing oc with `False` in message

With jsonpath of query is ignoring message.