### PR TITLE
Updated automation scripts and custom CRDs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -201,6 +201,11 @@ pipeline {
                 Should be the number of worker nodes on your cluster (after scaling)
             '''
         )
+        booleanParam(
+            name: 'CERBERUS_CHECK',
+            defaultValue: true,
+            description: 'Check cluster health status after workload runs'
+        )
         separator(
             name: 'NOPE_CONFIG_OPTIONS',
             sectionHeader: 'NOPE Configuration Options',
@@ -298,9 +303,12 @@ pipeline {
                 withCredentials([file(credentialsId: 'b73d6ed3-99ff-4e06-b2d8-64eaaf69d1db', variable: 'OCP_AWS')]) {
                     script {
                         buildinfo = readYaml file: 'flexy-artifacts/BUILDINFO.yml'
+                        buildinfo.params.each { env.setProperty(it.key, it.value) }
                         currentBuild.displayName = "${currentBuild.displayName}-${params.FLEXY_BUILD_NUMBER}"
                         currentBuild.description = "Flexy-install Job: <a href=\"${buildinfo.buildUrl}\">${params.FLEXY_BUILD_NUMBER}</a><br/>"
-                        buildinfo.params.each { env.setProperty(it.key, it.value) }
+                        installData = readYaml(file: 'flexy-artifacts/workdir/install-dir/cluster_info.yaml')
+                        env.MAJOR_VERSION = installData.INSTALLER.VER_X
+                        env.MINOR_VERSION = installData.INSTALLER.VER_Y
                         returnCode = sh(returnStatus: true, script: """
                             mkdir -p ~/.kube
                             cp $WORKSPACE/flexy-artifacts/workdir/install-dir/auth/kubeconfig ~/.kube/config
@@ -341,17 +349,19 @@ pipeline {
                         println "Successfully scaled cluster to ${params.WORKER_COUNT} worker nodes :)"
                         currentBuild.description += "Scale Job: <b><a href=${scaleJob.absoluteUrl}>${scaleJob.getNumber()}</a></b><br/>"
                         if (params.INFRA_WORKLOAD_INSTALL) {
-                            println 'Successfully installed infrastructure nodes :)'
+                            println 'Successfully installed infrastructure and workload nodes :)'
                         }
                         sh(returnStatus: true, script: '''
                             oc get nodes
-                            echo "Total Workers: `oc get nodes | grep worker | wc -l`"
+                            echo "Total Worker Nodes: `oc get nodes | grep worker | wc -l`"
+                            echo "Total Infra Nodes: `oc get nodes | grep infra | wc -l`"
+                            echo "Total Workload Nodes: `oc get nodes | grep workload | wc -l`"
                         ''')
                     }
                 }
             }
         }
-        stage('Install Netobserv Operator') {
+        stage('Install NetObserv Operator') {
             when {
                 expression { params.INSTALLATION_SOURCE != 'None' }
             }
@@ -382,14 +392,17 @@ pipeline {
         stage('Configure NOO, flowcollector, and Kafka') {
             steps {
                 script {
+                    // capture NetObserv release and add it to build description
+                    env.RELEASE = sh(returnStdout: true, script: "oc get pods -l app=netobserv-operator -o jsonpath='{.items[*].spec.containers[1].env[0].value}' -A").trim()
+                    currentBuild.description += "NetObserv Release: <b>${env.RELEASE}</b><br/>"
                     // attempt updating common parameters of NOO and flowcollector
                     println 'Updating common parameters of NOO and flowcollector...'
                     env.NAMESPACE = sh(returnStdout: true, script: "oc get pods -l app=netobserv-operator -o jsonpath='{.items[*].metadata.namespace}' -A").trim()
                     env.RELEASE = sh(returnStdout: true, script: "oc get pods -l app=netobserv-operator -o jsonpath='{.items[*].spec.containers[1].env[0].value}' -n ${NAMESPACE}").trim()
                     returnCode = sh(returnStatus: true, script: """
                         oc -n $NAMESPACE patch csv $RELEASE --type=json -p "[{"op": "replace", "path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/resources/limits/memory", "value": ${params.CONTROLLER_MEMORY_LIMIT}}]"
-			sleep 60
-			oc patch flowcollector cluster --type=json -p "[{"op": "replace", "path": "/spec/agent/ebpf/sampling", "value": ${params.FLP_SAMPLING_RATE}}] -n netobserv"
+                        sleep 60
+                        oc patch flowcollector cluster --type=json -p "[{"op": "replace", "path": "/spec/agent/ebpf/sampling", "value": ${params.FLP_SAMPLING_RATE}}] -n netobserv"
                         oc patch flowcollector cluster --type=json -p "[{"op": "replace", "path": "/spec/processor/resources/limits/cpu", "value": "${params.FLP_CPU_LIMIT}"}] -n netobserv"
                         oc patch flowcollector cluster --type=json -p "[{"op": "replace", "path": "/spec/processor/resources/limits/memory", "value": "${params.FLP_MEMORY_LIMIT}"}] -n netobserv"
                     """)
@@ -491,7 +504,8 @@ pipeline {
                         env.JENKINS_JOB = 'scale-ci/e2e-benchmarking-multibranch-pipeline/router-perf'
                         workloadJob = build job: env.JENKINS_JOB, parameters: [
                             string(name: 'BUILD_NUMBER', value: params.FLEXY_BUILD_NUMBER),
-                            booleanParam(name: 'CERBERUS_CHECK', value: true),
+                            booleanParam(name: 'CERBERUS_CHECK', value: params.CERBERUS_CHECK),
+                            booleanParam(name: 'MUST_GATHER', value: true),
                             string(name: 'JENKINS_AGENT_LABEL', value: params.JENKINS_AGENT_LABEL),
                             booleanParam(name: 'GEN_CSV', value: false)
                         ]
@@ -502,7 +516,7 @@ pipeline {
                             string(name: 'BUILD_NUMBER', value: params.FLEXY_BUILD_NUMBER),
                             string(name: 'WORKLOAD', value: params.WORKLOAD),
                             booleanParam(name: 'CLEANUP', value: true),
-                            booleanParam(name: 'CERBERUS_CHECK', value: true),
+                            booleanParam(name: 'CERBERUS_CHECK', value: params.CERBERUS_CHECK),
                             string(name: 'VARIABLE', value: params.VARIABLE), 
                             string(name: 'NODE_COUNT', value: params.NODE_COUNT),
                             booleanParam(name: 'GEN_CSV', value: false),

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -49,7 +49,7 @@ It is recommended to use Loki operator to create a LokiStack for Network Observa
         - Requirements: `m5.4xlarge` machines.
         - Use case: Standard performance/scale testing.
     * lokistack-1x-medium.yaml - Medium t-shirt size LokiStack
-        - Requirments: `m5.8xlarge` machines.
+        - Requirements: `m5.8xlarge` machines.
         - Use case: Large-scale performance/scale testing.
 
     Depending upon your cluster size and use case, run `$ oc apply -f <lokistack yaml manifest>`
@@ -67,7 +67,7 @@ You can update common parameters of flowcollector with the following commands:
 - **Replicas:** `$ oc patch flowcollector  cluster --type=json -p "[{"op": "replace", "path": "/spec/flowlogsPipeline/replicas", "value": <value>}]"`
 
 ### Install Kafka
-To install Kafka, run `./env.sh` to set environment variables required to deploy kafka. Run `$ source netobserv.sh ; deploy_kafka`
+To install Kafka, run `$ source netobserv.sh ; deploy_kafka`. Ensure you set `TOPIC_PARTITIONS` and `FLP_KAFKA_REPLICAS` environmental variables to your desired values first - otherwise values of `6` and `3` will be used, respectively.
 
 ### Using Dittybopper
 1. Navigate to the `scripts/` directory of this repository and run `$ setup_dittybopper_template`

--- a/scripts/catalogsources/qe-unreleased-catalogsource.yaml
+++ b/scripts/catalogsources/qe-unreleased-catalogsource.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: NetObservUnreleasedTesting
-  image: 'quay.io/openshift-qe-optional-operators/ocp4-index:latest'
+  image: 'quay.io/openshift-qe-optional-operators/aosqe-index:v${MAJOR_VERSION}.${MINOR_VERSION}'
   sourceType: grpc

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,3 +1,0 @@
-export DEFAULT_SC=$(oc get storageclass -o=jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
-export TOPIC_PARTITIONS=6
-export FLP_KAFKA_REPLICAS=3

--- a/scripts/subscriptions/netobserv-operatorhub-subscription.yaml
+++ b/scripts/subscriptions/netobserv-operatorhub-subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: netobserv-operator
   namespace: openshift-operators
 spec:
-  channel: v0.2.x
+  channel: v1.0.x
   name: netobserv-operator
   source: community-operators
   sourceNamespace: openshift-marketplace 


### PR DESCRIPTION
Changes made:
- Made `CERBERUS_CHECK` optional for increased flexibility
- Explicitly set `MUST_GATHER` to run in the event of a Cerberus failure
- Added NetObserv version info to Jenkins build desc
- Added additional logging around infra and workload nodes
- Switched unreleased catalogsource to use `aosqe-index` image instead of `ocp4-latest`
- Fixed bug where `nukeobserv` would fail if a `NAMESPACE` var wasn't able to be parsed
- Fixed bug where `nukeobserv` didn't delete `qe-unreleased-testing` CatalogSource
- Removed  `env.sh` file and moved functionality to `netobserv.sh`
- Updated `OperatorHub` subscription channel