### PR TITLE
add infra, workload MCPs

### DIFF
--- a/mcp-infra.yaml
+++ b/mcp-infra.yaml
@@ -1,0 +1,11 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: infra
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker,infra]} 
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/infra: ""

--- a/mcp-workload.yaml
+++ b/mcp-workload.yaml
@@ -1,0 +1,11 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: workload
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker,workload]} 
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/workload: ""


### PR DESCRIPTION
After removing the default `worker` role from the `infra, workload` node, we should add the related `MCP` for them. Otherwise, it will lead to some configs cannot be applied. Details: https://issues.redhat.com/browse/OCPBUGS-10596 