### PR TITLE
Added user ID to AWS bucket name generation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -390,6 +390,13 @@ pipeline {
                     if (params.LOKI_OPERATOR == 'Unreleased') {
                         env.IMAGE = "quay.io/openshift-qe-optional-operators/aosqe-index:v${MAJOR_VERSION}.${MINOR_VERSION}"
                     }
+                    // set USER variable to be included in AWS bucket name
+                    if (userId) {
+                        env.USER = userId
+                    }
+                    else {
+                        env.USER = 'auto'
+                    }
                     // attempt installation of Loki Operator from selected source
                     println "Installing ${params.LOKI_OPERATOR} version of Loki Operator..."
                     returnCode = sh(returnStatus: true, script: """

--- a/scripts/netobserv.sh
+++ b/scripts/netobserv.sh
@@ -84,9 +84,9 @@ deploy_lokistack() {
   echo "====> Generate S3_BUCKETNAME"
   RAND_SUFFIX=$(tr </dev/urandom -dc 'a-z0-9' | fold -w 12 | head -n 1 || true)
   if [[ $WORKLOAD == "None" ]] || [[ -z $WORKLOAD ]]; then
-    export S3_BUCKETNAME="netobserv-ocpqe-perf-loki-$RAND_SUFFIX"
+    export S3_BUCKETNAME="netobserv-ocpqe-$USER-$RAND_SUFFIX"
   else
-    export S3_BUCKETNAME="netobserv-ocpqe-perf-loki-$WORKLOAD-$RAND_SUFFIX"
+    export S3_BUCKETNAME="netobserv-ocpqe-$USER-$WORKLOAD-$RAND_SUFFIX"
   fi
 
   # if cluster is to be preserved, do the same for S3 bucket


### PR DESCRIPTION
tested locally 
```bash
[nathan@nathan-redhat ocp]$ cat temp.sh 
echo "====> Generate S3_BUCKETNAME"
RAND_SUFFIX=$(tr </dev/urandom -dc 'a-z0-9' | fold -w 12 | head -n 1 || true)
if [[ $WORKLOAD == "None" ]] || [[ -z $WORKLOAD ]]; then
  export S3_BUCKETNAME="netobserv-ocpqe-$USER-$RAND_SUFFIX"
else
  export S3_BUCKETNAME="netobserv-ocpqe-$USER-$WORKLOAD-$RAND_SUFFIX"
fi
echo $S3_BUCKETNAME
[nathan@nathan-redhat ocp]$ ./temp.sh 
====> Generate S3_BUCKETNAME
netobserv-ocpqe-nathan-6t66njkdcn7f
```
and also Jenkins
```bash
03-22 14:41:38.786  + echo '====> Generate S3_BUCKETNAME'
03-22 14:41:38.786  ====> Generate S3_BUCKETNAME
03-22 14:41:38.786  ++ tr -dc a-z0-9
03-22 14:41:38.786  ++ fold -w 12
03-22 14:41:38.786  ++ head -n 1
03-22 14:41:38.786  + RAND_SUFFIX=hbovazxwn6l2
03-22 14:41:38.786  + [[ None == \N\o\n\e ]]
03-22 14:41:38.786  + export S3_BUCKETNAME=netobserv-ocpqe-nweinber-hbovazxwn6l2
03-22 14:41:38.786  + S3_BUCKETNAME=netobserv-ocpqe-nweinber-hbovazxwn6l2
03-22 14:41:38.786  ++ oc get infrastructure cluster -o 'jsonpath={.status.infrastructureName}'
03-22 14:41:39.041  + CLUSTER_NAME=nweinber-preserve-kkd6s
03-22 14:41:39.041  + [[ nweinber-preserve-kkd6s =~ preserve ]]
03-22 14:41:39.041  + S3_BUCKETNAME+=-preserve
03-22 14:41:39.041  + echo '====> S3_BUCKETNAME is netobserv-ocpqe-nweinber-hbovazxwn6l2-preserve'
03-22 14:41:39.041  ====> S3_BUCKETNAME is netobserv-ocpqe-nweinber-hbovazxwn6l2-preserve
```