### PR TITLE
Update Jenkinsfile to support mulit-arch ocp

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -687,10 +687,19 @@ pipeline{
                     currentBuild.description += """
                         <b>Upgrade to: </b> ${UPGRADE_VERSION} <br/>
                     """
+		    def set_arch_type = "x86_64"
+                    if (params.ARCH_TYPE != "") {
+                          set_arch_type = params.ARCH_TYPE
+                     }
+                    else if (params.CI_PROFILE != "" && params.CI_PROFILE.contains('ARM')) {
+                          set_arch_type = "aarch64"
+                     }	
+			
                     upgrade_ci = build job: "scale-ci/e2e-benchmarking-multibranch-pipeline/upgrade", propagate: false,parameters:[
                         string(name: "BUILD_NUMBER", value: build_string),string(name: "MAX_UNAVAILABLE", value: MAX_UNAVAILABLE),
                         string(name: "JENKINS_AGENT_LABEL", value: JENKINS_AGENT_LABEL),string(name: "UPGRADE_VERSION", value: UPGRADE_VERSION),
-                        booleanParam(name: "EUS_UPGRADE", value: EUS_UPGRADE),string(name: "EUS_CHANNEL", value: EUS_CHANNEL),
+			string(name: "ARCH_TYPE", value: set_arch_type),
+			booleanParam(name: "EUS_UPGRADE", value: EUS_UPGRADE),string(name: "EUS_CHANNEL", value: EUS_CHANNEL),
                         booleanParam(name: "WRITE_TO_FILE", value: WRITE_TO_FILE),booleanParam(name: "ENABLE_FORCE", value: ENABLE_FORCE),
                         booleanParam(name: "SCALE", value: SCALE),text(name: "ENV_VARS", value: ENV_VARS)
                     ]


### PR DESCRIPTION
To upgrade multi-arch OCP, It's hard to automatically detect if the OCP is multi-arch like as arm and x86, so need to specify arch type when you plan to upgrade multi-arch OCP

The Jenkins Logs:
Upgrade multi-arch to nightly version:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/liqcui-e2e-benchmarking-multibranch-pipeline/job/loaded-upgrade/64/

Upgrade multi-arch to stable version:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/liqcui-e2e-benchmarking-multibranch-pipeline/job/loaded-upgrade/65/