### PR TITLE
adding baseline option

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -257,10 +257,10 @@ pipeline {
                             """)
                         }
                         // fail pipeline if NOPE run failed, continue otherwise
-                        if (result_returnCode.toInteger() == 2) {
+                        if (result_returnCode.toInteger() == 2 || baseline_returnCode.toInteger() == 2) {
                             unstable('ES post tool ran, but Elasticsearch upload failed - check build artifacts for data and try uploading it locally :/')
                         }
-                        else if ( result_returnCode.toInteger() != 0) {
+                        else if ( result_returnCode.toInteger() != 0 || baseline_returnCode.toInteger() != 0) {
                             error('Post to ES tool failed :(')
                         }
                         else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,6 +50,11 @@ pipeline {
                 font-family: 'Orienta', sans-serif;
             '''
         )
+        booleanParam(
+            name: 'UPLOAD_BASELINE',
+            defaultValue: false,
+            description: 'Upload baseline data if one is not found'
+        )
         choice(
           choices: ["cluster-density","node-density","node-density-heavy","pod-density","pod-density-heavy","max-namespaces","max-services", "concurrent-builds","network-perf","router-perf","etcd-perf","nightly-regression","loaded-upgrade","upgrade","nightly-regression-longrun"], 
           name: 'WORKLOAD', 
@@ -243,11 +248,14 @@ pipeline {
                             python post_uuid_to_es.py --user $GLOBAL_USER_ID --baseline false
                         """)
 
-                        // post a new baseline uuid if one doesn't exist
-                        // baseline_returnCode = sh(returnStatus: true, script: """
-                        //     python --version
-                        //     python post_uuid_to_es.py --jenkins-job $JENKINS_JOB_PATH --jenkins-build $JENKINS_JOB_NUMBER --uuid $env.UUID --user $GLOBAL_USER_ID --baseline true
-                        // """)
+                        if ( params.UPLOAD_BASELINE == true ) {
+                          // post a new baseline uuid if one doesn't exist
+                            baseline_returnCode = sh(returnStatus: true, script: """
+                                source venv3/bin/activate
+                                python --version
+                                python post_uuid_to_es.py --user $GLOBAL_USER_ID --baseline true
+                            """)
+                        }
                         // fail pipeline if NOPE run failed, continue otherwise
                         if (result_returnCode.toInteger() == 2) {
                             unstable('ES post tool ran, but Elasticsearch upload failed - check build artifacts for data and try uploading it locally :/')

--- a/helper_uuid.py
+++ b/helper_uuid.py
@@ -64,18 +64,6 @@ def find_cloud_name(launcher_vars):
     print('fin sub profile ' + str(final_sub))
     return final_sub
 
-def find_uuid(read_json, ocp_version, cluster_worker_count, network_type_string, cluster_arch_type):
-
-    for json_versions, sub_vers_json in read_json.items(): 
-        if str(json_versions) == str(ocp_version):
-            for worker_count, sub_worker_json in sub_vers_json.items():
-                if str(cluster_worker_count) == str(worker_count):
-                    if "ovn" in network_type_string.lower():
-                        network_type = "OVN"
-                    else:
-                        network_type = "SDN"
-                    return sub_worker_json[network_type][cluster_arch_type]
-
 def get_scale_profile_name(version, arch, net_type, worker_count):
     sub_version_split = version.split('.')
     sub_version = sub_version_split[0] + "." + sub_version_split[1]
@@ -146,9 +134,10 @@ def find_uuid(workload, metric_name):
     if len(hits) == 0: 
         search_params["LAUNCHER_VARS"] = var_loc.replace("-ci","")
         hits = update_es_uuid.es_search(search_params)
+
         if len(hits) == 0: 
-            print("")
+            return False
         else: 
-            print(hits[0]['_source']['uuid'])
+            return hits[0]['_source']['uuid']
     else: 
-        print(hits[0]['_source']['uuid'])
+        return hits[0]['_source']['uuid']

--- a/post_uuid_to_es.py
+++ b/post_uuid_to_es.py
@@ -135,7 +135,7 @@ def get_scale_ci_data():
                 info['parameters'] = int(param.get('value'))
     except Exception as e:
         logging.error(f"Failed to collect Jenkins build parameter info: {e}")
-    info["uuid"] =  UUID
+    info["uuid"] =  os.getenv('UUID')
     return info
 
 def get_nightly_reg_data(): 
@@ -293,7 +293,8 @@ if __name__ == '__main__':
         # if data already exists, don't post 
         METRIC_NAME = "base_line_uuids"
         base_line_uuid = helper_uuid.find_uuid(workload, METRIC_NAME)
-        if base_line_uuid != "":
+        print('baseline ' + str(base_line_uuid))
+        if base_line_uuid is not False:
             logging.info("Baseline UUID for this configuration is already set")
             sys.exit(0)
     else: 
@@ -350,7 +351,7 @@ if __name__ == '__main__':
         for k,v in jenkins_info.items(): 
             info[k] = v
     RESULTS['data'].append(info)
-    logging.info(f"UUID: {os.getenv('UUID')}")
+    
 
     if (ES_USERNAME is None) or (ES_PASSWORD is None):
         logging.error("Credentials need to be set to upload data to Elasticsearch")


### PR DESCRIPTION
Adding new option to be able to upload to baselines when none exists for certain configurations, this is off by default but would be helpful for new configurations

Won't upload if data for certain configuration is already out there: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/paige-e2e-multibranch/job/post-results-to-es/13/console

Post new baseline if none exists: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/paige-e2e-multibranch/job/post-results-to-es/10/console