### PR TITLE
Adding workloads and iterations

### DIFF
--- a/scripts/sandman.py
+++ b/scripts/sandman.py
@@ -28,9 +28,9 @@ def main():
         starttime_regex = base_regex + 'Starting'
         endtime_regex = base_regex + 'Exiting'
         strptime_filter = '%Y-%m-%d %H:%M:%S'
-        
         workload_regex = 'Job '
         workload_end_regex = ':'
+
         # capture and log strings representations of workload name
         workload_first_str = workload_logs.split(workload_regex)[1]
         workload_type = workload_first_str.split(workload_end_regex)[0]

--- a/scripts/sandman.py
+++ b/scripts/sandman.py
@@ -122,7 +122,7 @@ def main():
     # write timestamp data to data directory
     with open(DATA_DIR + f'/workload.json', 'w') as data_file:
         json.dump(workload_data, data_file)
-        
+
     # exit if no issues
     sys.exit(0)
 

--- a/scripts/sandman.py
+++ b/scripts/sandman.py
@@ -104,7 +104,6 @@ def main():
     # Depending on the workload, we want to find the uuid (not existent for network-perf-v2)
     # Specific regex configurations set based on file type above 
     if uuid_exists:
-        # rework to use an end
         uuid = re.findall(uuid_regex, workload_logs)[0].split('"')[0]
         print(f"uuid: {uuid}")
         workload_data['uuid'] = str(uuid)
@@ -124,7 +123,6 @@ def main():
     with open(DATA_DIR + f'/workload.json', 'w') as data_file:
         json.dump(workload_data, data_file)
         
-
     # exit if no issues
     sys.exit(0)
 

--- a/scripts/sandman.py
+++ b/scripts/sandman.py
@@ -21,8 +21,8 @@ def main():
     
     uuid_exists = True
     iterations_exists = True
-    # initialize regexs
-    
+
+    # initialize regexs based on file type
     if "kube-burner-ocp" in WORKLOAD_OUT_FILE:
         base_regex = 'time="(\d+-\d+-\d+ \d+:\d+:\d+)".*'
         starttime_regex = base_regex + 'Starting'
@@ -61,7 +61,6 @@ def main():
         else: 
             iterations_start = "Job iterations: "
             iterations_end = "\n"
-
         
     elif "ingress_router" in WORKLOAD_OUT_FILE:
         base_regex = '([a-zA-z]{3}\s+\d+ \d+:\d+:\d+ [a-zA-z]{3} \d+).*'
@@ -102,12 +101,16 @@ def main():
         "endtime_timestamp": str(endtime_timestamp)
     }
 
+    # Depending on the workload, we want to find the uuid (not existent for network-perf-v2)
+    # Specific regex configurations set based on file type above 
     if uuid_exists:
         # rework to use an end
         uuid = re.findall(uuid_regex, workload_logs)[0].split('"')[0]
         print(f"uuid: {uuid}")
         workload_data['uuid'] = str(uuid)
 
+    # Depending on the workload, we want to find the number of iterations 
+    # Specific regex configurations set based on file type above 
     if iterations_exists:
         # rework to use an end
         iterations = workload_logs.split(iterations_start)[1].split(iterations_end)[0]

--- a/scripts/sandman.py
+++ b/scripts/sandman.py
@@ -35,9 +35,12 @@ def main():
         workload_first_str = workload_logs.split(workload_regex)[1]
         workload_type = workload_first_str.split(workload_end_regex)[0]
         uuid_regex = 'UUID (.*)"'
-
-        iterations_start = " --iterations="
-        iterations_end = " "
+        if "node-density" in workload_type:
+            iterations_start = " --pods-per-node="
+            iterations_end = " "
+        else: 
+            iterations_start = " --iterations="
+            iterations_end = " "
 
     elif "kube-burner" in WORKLOAD_OUT_FILE:
         base_regex = 'time="(\d+-\d+-\d+ \d+:\d+:\d+)".*'
@@ -52,8 +55,12 @@ def main():
         uuid_regex = 'UUID: (.*)"'
 
         #find iterations 
-        iterations_start = "Job iterations: "
-        iterations_end = "\n"
+        if "node-density" in workload_type:
+            iterations_start = "Pods per node: "
+            iterations_end = "\n"
+        else: 
+            iterations_start = "Job iterations: "
+            iterations_end = "\n"
 
         
     elif "ingress_router" in WORKLOAD_OUT_FILE:

--- a/scripts/sandman.py
+++ b/scripts/sandman.py
@@ -33,7 +33,7 @@ def main():
         workload_end_regex = ':'
         # capture and log strings representations of workload name
         workload_first_str = workload_logs.split(workload_regex)[1]
-        workload_second_str = workload_first_str.split(workload_end_regex)[0]
+        workload_type = workload_first_str.split(workload_end_regex)[0]
         uuid_regex = 'UUID (.*)"'
 
         iterations_start = " --iterations="
@@ -48,7 +48,7 @@ def main():
         workload_regex = 'Workload: '
         workload_end_regex = '\n'
         # capture and log strings representations of workload name
-        workload_first_str = workload_logs.split(workload_regex)[1].split(workload_end_regex)[0]
+        workload_type = workload_logs.split(workload_regex)[1].split(workload_end_regex)[0]
         uuid_regex = 'UUID: (.*)"'
 
         #find iterations 
@@ -63,6 +63,7 @@ def main():
         strptime_filter = '%b %d %H:%M:%S %Z %Y'
         uuid_regex = 'UUID: (.*)"'
         iterations_exists = False
+        workload_type = "router-perf"
 
     elif "network-perf-v2" in WORKLOAD_OUT_FILE:
         base_regex = 'time="(\d+-\d+-\d+ \d+:\d+:\d+)".*'
@@ -71,6 +72,7 @@ def main():
         strptime_filter = '%Y-%m-%d %H:%M:%S'
         uuid_exists = False
         iterations_exists = False
+        workload_type = "network-perf-v2"
     
     # capture and log strings representations of start and end times
     starttime_string = re.findall(starttime_regex, workload_logs)[0]
@@ -86,6 +88,7 @@ def main():
 
     # construct JSON of workload data
     workload_data = {
+        "workload_type": str(workload_type),
         "starttime_string": str(starttime_string),
         "endtime_string": str(endtime_string),
         "starttime_timestamp": str(starttime_timestamp),
@@ -110,6 +113,7 @@ def main():
     # write timestamp data to data directory
     with open(DATA_DIR + f'/workload.json', 'w') as data_file:
         json.dump(workload_data, data_file)
+        
 
     # exit if no issues
     sys.exit(0)

--- a/scripts/sandman.py
+++ b/scripts/sandman.py
@@ -54,7 +54,7 @@ def main():
         workload_type = workload_logs.split(workload_regex)[1].split(workload_end_regex)[0]
         uuid_regex = 'UUID: (.*)"'
 
-        #find iterations 
+        # find iterations 
         if "node-density" in workload_type:
             iterations_start = "Pods per node: "
             iterations_end = "\n"

--- a/scripts/sandman.py
+++ b/scripts/sandman.py
@@ -20,24 +20,57 @@ def main():
         workload_logs = out_file.read()
     
     uuid_exists = True
+    iterations_exists = True
     # initialize regexs
-    if "kube-burner" in WORKLOAD_OUT_FILE:
+    
+    if "kube-burner-ocp" in WORKLOAD_OUT_FILE:
         base_regex = 'time="(\d+-\d+-\d+ \d+:\d+:\d+)".*'
         starttime_regex = base_regex + 'Starting'
         endtime_regex = base_regex + 'Exiting'
         strptime_filter = '%Y-%m-%d %H:%M:%S'
+        
+        workload_regex = 'Job '
+        workload_end_regex = ':'
+        # capture and log strings representations of workload name
+        workload_first_str = workload_logs.split(workload_regex)[1]
+        workload_second_str = workload_first_str.split(workload_end_regex)[0]
+        uuid_regex = 'UUID (.*)"'
+
+        iterations_start = " --iterations="
+        iterations_end = " "
+
+    elif "kube-burner" in WORKLOAD_OUT_FILE:
+        base_regex = 'time="(\d+-\d+-\d+ \d+:\d+:\d+)".*'
+        starttime_regex = base_regex + 'Starting'
+        endtime_regex = base_regex + 'Exiting'
+        strptime_filter = '%Y-%m-%d %H:%M:%S'
+        
+        workload_regex = 'Workload: '
+        workload_end_regex = '\n'
+        # capture and log strings representations of workload name
+        workload_first_str = workload_logs.split(workload_regex)[1].split(workload_end_regex)[0]
+        uuid_regex = 'UUID: (.*)"'
+
+        #find iterations 
+        iterations_start = "Job iterations: "
+        iterations_end = "\n"
+
+        
     elif "ingress_router" in WORKLOAD_OUT_FILE:
         base_regex = '([a-zA-z]{3}\s+\d+ \d+:\d+:\d+ [a-zA-z]{3} \d+).*'
         starttime_regex = base_regex + 'Testing'
         endtime_regex = base_regex + 'Enabling'
         strptime_filter = '%b %d %H:%M:%S %Z %Y'
-    
+        uuid_regex = 'UUID: (.*)"'
+        iterations_exists = False
+
     elif "network-perf-v2" in WORKLOAD_OUT_FILE:
         base_regex = 'time="(\d+-\d+-\d+ \d+:\d+:\d+)".*'
         starttime_regex = base_regex + ' Reading'
         endtime_regex = base_regex + 'Rendering'
         strptime_filter = '%Y-%m-%d %H:%M:%S'
         uuid_exists = False
+        iterations_exists = False
     
     # capture and log strings representations of start and end times
     starttime_string = re.findall(starttime_regex, workload_logs)[0]
@@ -60,10 +93,16 @@ def main():
     }
 
     if uuid_exists:
-        uuid_regex = 'UUID: (.*)"'
-        uuid = re.findall(uuid_regex, workload_logs)[0]
+        # rework to use an end
+        uuid = re.findall(uuid_regex, workload_logs)[0].split('"')[0]
         print(f"uuid: {uuid}")
         workload_data['uuid'] = str(uuid)
+
+    if iterations_exists:
+        # rework to use an end
+        iterations = workload_logs.split(iterations_start)[1].split(iterations_end)[0]
+        print(f"iterations: {iterations}")
+        workload_data['iteratons'] = str(iterations)
 
     # ensure data directory exists (create if not)
     pathlib.Path(DATA_DIR).mkdir(parents=True, exist_ok=True)

--- a/scripts/sandman.py
+++ b/scripts/sandman.py
@@ -47,9 +47,9 @@ def main():
         starttime_regex = base_regex + 'Starting'
         endtime_regex = base_regex + 'Exiting'
         strptime_filter = '%Y-%m-%d %H:%M:%S'
-        
         workload_regex = 'Workload: '
         workload_end_regex = '\n'
+
         # capture and log strings representations of workload name
         workload_type = workload_logs.split(workload_regex)[1].split(workload_end_regex)[0]
         uuid_regex = 'UUID: (.*)"'


### PR DESCRIPTION
Adding workload type to workload_data and number of iterations if they exist


Router perf: {'workload_type': 'router-perf', 'starttime_string': 'May 29 14:13:39 UTC 2023', 'endtime_string': 'May 29 14:44:16 UTC 2023', 'starttime_timestamp': '1685369619', 'endtime_timestamp': '1685371456', 'uuid': '5849d764-1bec-4f4b-a397-687b0f286b6a'}

Kube-burner-ocp: {'workload_type': 'cluster-density-v2', 'starttime_string': '2023-05-25 21:45:37', 'endtime_string': '2023-05-25 22:01:49', 'starttime_timestamp': '1685051137', 'endtime_timestamp': '1685052109', 'uuid': '13a1f64b-68c4-4def-ac6c-25014d21140c', 'iteratons': '180'}