### PR TITLE
Removed all profile porting in FlowCollector

### DIFF
--- a/scripts/netobserv/flows_v1beta1_flowcollector.yaml
+++ b/scripts/netobserv/flows_v1beta1_flowcollector.yaml
@@ -20,9 +20,6 @@ spec:
           cpu: 100m
           memory: 50Mi
       sampling: 1
-      debug:
-        env:
-          PORT_PROFILE: "6060"
     ipfix:
       cacheActiveTimeout: 20s
       cacheMaxFlows: 400
@@ -139,7 +136,6 @@ spec:
         tls:
           type: DISABLED
     port: 2055
-    profilePort: 6060
     resources:
       limits:
         memory: 800Mi


### PR DESCRIPTION
As discussed on Slack, it turns out there are some performance overheads around having profile porting enabled for eBPF and FLP in our FlowCollector CRD. Disabling having those enabled by default - we will introduce Jenkins and Shell scripting options to allow these to be enabled by users if they are needed.