### PR TITLE
Adding more workload type and get data for network-perf type

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,10 @@ pipeline {
             description: 'Upload baseline data if one is not found'
         )
         choice(
-          choices: ["cluster-density","node-density","node-density-heavy","pod-density","pod-density-heavy","max-namespaces","max-services", "concurrent-builds","network-perf","network-perf-v2","router-perf","etcd-perf","nightly-regression","loaded-upgrade","upgrade","nightly-regression-longrun"], 
+          choices: ["cluster-density","node-density","node-density-heavy","pod-density","pod-density-heavy","max-namespaces","max-services",
+            "node-density-cni","cluster-density-ms","pods-service-route","networkpolicy-case1","networkpolicy-case2","networkpolicy-case3"
+            "concurrent-builds","network-perf","network-perf-v2","router-perf","etcd-perf","nightly-regression","loaded-upgrade","upgrade",
+            "nightly-regression-longrun"], 
           name: 'WORKLOAD', 
           description: '''Type of kube-burner job to run'''
         )

--- a/post_uuid_to_es.py
+++ b/post_uuid_to_es.py
@@ -138,6 +138,19 @@ def get_scale_ci_data():
     info["uuid"] =  os.getenv('UUID')
     return info
 
+def get_net_perf_v2_data(): 
+    info = {}
+    build_parameters = get_jenkins_params()
+    try: 
+        for param in build_parameters:
+            del param['_class']
+            if param.get('name') == 'WORKLOAD_TYPE':
+                info['WORKLOAD_TYPE'] = str(param.get('value'))
+    except Exception as e:
+        logging.error(f"Failed to collect Jenkins build parameter info: {e}")
+    info["uuid"] =  os.getenv('UUID')
+    return info
+
 def get_nightly_reg_data(): 
     info = {}
     build_parameters = get_jenkins_params()
@@ -344,6 +357,10 @@ if __name__ == '__main__':
             info[k] = v
     elif workload == "loaded-upgrade": 
         jenkins_info = get_loaded_up_data()
+        for k,v in jenkins_info.items(): 
+            info[k] = v
+    elif "network-perf" in workload:
+        jenkins_info = get_net_perf_v2_data()
         for k,v in jenkins_info.items(): 
             info[k] = v
     elif "nightly" not in workload:


### PR DESCRIPTION
Missing more workload types that are available in kube-burner and kube-burner-ocp

Want to also be able to get the workload type for network perf in the results post to es