### PR TITLE
adding cleanup variable for kube-burner

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
 def userCause = currentBuild.rawBuild.getCause(Cause.UserIdCause)
 def upstreamCause = currentBuild.rawBuild.getCause(Cause.UpstreamCause)
 
-userId = "prubenda"
+userId = "ocp-perfscale-qe"
 if (userCause) {
     userId = userCause.getUserId()
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -274,6 +274,7 @@ pipeline {
                         elif [[ $WORKLOAD == *"node-density"* ]]; then
                             export EXTRA_FLAGS="$EXTRA_FLAGS --pods-per-node=$VARIABLE"
                         fi
+                        export GC=${CLEANUP}
                         ./run.sh |& tee "kube-burner-ocp.out"
 
                     ''')


### PR DESCRIPTION
The variable to cleanup the resources or not in the kube-burner ocp version is called GC. Going to leave the upper variable because it is passed and used in other places as well 

https://github.com/cloud-bulldozer/e2e-benchmarking/blob/2ecfb160cf8e57fac8a8c4c366893a02e40af0af/workloads/kube-burner-ocp-wrapper/run.sh#L12