### PR TITLE
Adding find uuid for network perf v2

### DIFF
--- a/scripts/sandman.py
+++ b/scripts/sandman.py
@@ -77,7 +77,7 @@ def main():
         starttime_regex = base_regex + ' Reading'
         endtime_regex = base_regex + 'Rendering'
         strptime_filter = '%Y-%m-%d %H:%M:%S'
-        uuid_exists = False
+        uuid_regex = 'UUID (.*)"'
         iterations_exists = False
         workload_type = "network-perf-v2"
     
@@ -112,9 +112,12 @@ def main():
     # Depending on the workload, we want to find the uuid (not existent for network-perf-v2)
     # Specific regex configurations set based on file type above 
     if uuid_exists:
-        uuid = re.findall(uuid_regex, workload_logs)[0].split('"')[0]
-        print(f"uuid: {uuid}")
-        workload_data['uuid'] = str(uuid)
+        try: 
+            uuid = re.findall(uuid_regex, workload_logs)[0].split('"')[0]
+            print(f"uuid: {uuid}")
+            workload_data['uuid'] = str(uuid)
+        except: 
+            print("No uuid found")
 
     # Depending on the workload, we want to find the number of iterations 
     # Specific regex configurations set based on file type above 


### PR DESCRIPTION
In some of the newer network-perf-v2 tests there is a print off of a UUID. Want to be able to get that uuid if it exists. Does not exist in all output files of network-perf-v2. The except will hopefully catch these cases but we wont want to do anything
See output file here: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/network-perf-v2/33/

I had 3 versions of output files and these are the results of running these edits here
```
% python scripts/sandman.py --file network-perf-v2-new.out
starttime_string: 2023-07-07 08:48:15
endtime_string: 2023-07-07 10:15:51
starttime_timestamp: 1688719695
endtime_timestamp: 1688724951
uuid: b57e9a5a-ec41-413d-a045-c09b29500f0f
 % python scripts/sandman.py --file network-perf-v2.out    
starttime_string: 2023-07-04 09:24:31
endtime_string: 2023-07-04 09:58:19
starttime_timestamp: 1688462671
endtime_timestamp: 1688464699
No uuid found
 % python scripts/sandman.py --file network-perf-v2-old.out
starttime_string: 2023-05-18 14:48:08
endtime_string: 2023-05-18 14:50:50
starttime_timestamp: 1684421288
endtime_timestamp: 1684421450
No uuid found
```