### PR TITLE
Adding ingress perf sandman get uuid

### DIFF
--- a/scripts/sandman.py
+++ b/scripts/sandman.py
@@ -71,6 +71,14 @@ def main():
         uuid_regex = 'UUID: (.*)"'
         iterations_exists = False
         workload_type = "router-perf"
+    elif "ingress_perf" in WORKLOAD_OUT_FILE:
+        base_regex = 'time="(\d+-\d+-\d+ \d+:\d+:\d+)".*'
+        starttime_regex = base_regex + 'Running'
+        endtime_regex = base_regex + 'Cleaning'
+        strptime_filter = '%Y-%m-%d %H:%M:%S'
+        uuid_regex = 'Running ingress performance (.*)"'
+        iterations_exists = False
+        workload_type = "ingress-perf"
 
     elif "network-perf-v2" in WORKLOAD_OUT_FILE:
         base_regex = 'time="(\d+-\d+-\d+ \d+:\d+:\d+)".*'


### PR DESCRIPTION
Want to be able to get uuid, start and end times using sandman script for new ingress perf test 

Used output from this run: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/paige-e2e-multibranch/job/ingress-perf/5/

```
starttime_string: 2023-07-21 16:37:26
endtime_string: 2023-07-21 17:45:06
starttime_timestamp: 1689957446
endtime_timestamp: 1689961506
uuid: a682b97e-53ff-44c2-a4bd-8bc4a320a290
```