### PR TITLE
Updated README and LokiStack CRDs with new stream limits config

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -103,15 +103,9 @@ MAX_WAIT_TIMEOUT=10m
 ```
 
 ## Network Observability Prometheus and Elasticsearch tool (NOPE)
-The Network Observability Prometheus and Elasticsearch tool, or NOPE, is a Python program that is used for collecting and sharing performance data for a given OpenShift cluster running the Network Observability Operator, using Prometheus range queries for collection and Elasticsearch servers for sharing.
+The Network Observability Prometheus and Elasticsearch tool, or NOPE, is a Python program that is used for collecting and sharing performance data for a given OpenShift cluster running the Network Observability Operator, using Prometheus range queries for collection and Elasticsearch servers for storage. It also has run modes for uploading local JSON files to Elasticsearch as well as setting and fetching baselines for given workloads.
 
-Queries are sourced from the `netobserv_prometheus_queries.yaml` file within the `scripts/queries/` directory by default - check out that file to see what data the NOPE tool is collecting. Note this can be overriden with the `--yaml-file` flag to run other queries from within other files.
-
-Gathered data can be tied to specific UUIDs and/or Jenkins jobs using specific flags - see the below section for more information. You can also tie a run to a Jira ticket if applicable using the `--jira` flag. 
-
-If no Elasticsearch server is available to be uploaded to, a raw JSON file will be written to the `data/` directory in the project - note this directory will be created automatically if it does not already exist. You can also explictily dump data to a JSON file rather than upload to Elasticsearch with the `--dump` flag.
-
-### Running the NOPE tool
+### Prerequisties
 1. Ensure you have Python 3.9+ and Pip installed (verify with `python --version` and `pip --version`)
 2. Install requirements with `pip install -r scripts/requirements.txt`
 3. If you wish to upload to Elasticsearch, set the following environmental variables:
@@ -123,7 +117,18 @@ $ export ES_PASSWORD=<elasticsearch password>
 
 To see all command line options available for the NOPE tool, you can run it with the `--help` argument.
 
-Note that if you are running the NOPE tool in Upload mode by passing the `--upload-file` flag all other flags will be ignored. You do not need to be connected to an OpenShift cluster if you are running in Upload mode.
+### Standard Mode
+Prometheus queries are sourced from the `netobserv_prometheus_queries.yaml` file within the `scripts/queries/` directory by default - check out that file to see what data the NOPE tool is collecting. Note this can be overriden with the `--yaml-file` flag to run other queries from within other files.
+
+Gathered data can be tied to specific UUIDs and/or Jenkins jobs using specific flags - see the below section for more information. You can also tie a run to a Jira ticket if applicable using the `--jira` flag. 
+
+If no Elasticsearch server is available to be uploaded to, a raw JSON file will be written to the `data/` directory in the project - note this directory will be created automatically if it does not already exist. You can also explictily dump data to a JSON file rather than upload to Elasticsearch with the `--dump` flag.
+
+### Upload Mode
+Data that has been dumped to a JSON file, either due to an issue with Elasticsearch of done explicitly, can be uploaded to Elasticsearch later using the NOPE tool's Upload mode. Note that the specified JSON file must be in the `data/` directory. Also, you do not need to be connected to an OpenShift cluster if you are running in Upload mode.
+
+### Baseline Mode
+The NOPE tool can also be used for fetching and uploading baselines on a workload-by-workload basis by running it in Baseline mode. Fetching is based on workloads and ISO timestamps - for a given workload, the NOPE tool will fetch the latest baseline present on the specified Elasticsearch server and dump the UUID of that baseline to a `baseline.json` file in the `data/` directory. Uploading is based on UUID - the NOPE tool will gather data about the test run on the specified UUID and create a new baseline document in Elasticsearch. Note you do not need to be connected to an OpenShift cluster if you are running in Baseline mode.
 
 ## Fetching metrics using Touchstone 
 NetObserv metrics uploaded to Elasticsearch can be fetched using `touchstone` tool provided by [benchmark-comparison](https://github.com/cloud-bulldozer/benchmark-comparison). Once you have Touchstone set up, you can run it with any given UUID using the `netobserv_touchstone_statistics_config.json` file in the `queries/` directory under `scripts/`

--- a/scripts/loki/lokistack-1x-exsmall.yaml
+++ b/scripts/loki/lokistack-1x-exsmall.yaml
@@ -10,6 +10,8 @@ spec:
         ingestionBurstSize: 100
         ingestionRate: 500
         maxGlobalStreamsPerTenant: 100000
+        perStreamRateLimit: 6
+        perStreamRateLimitBurst: 30
   tenants:
     mode: openshift-network
   managementState: Managed

--- a/scripts/loki/lokistack-1x-medium.yaml
+++ b/scripts/loki/lokistack-1x-medium.yaml
@@ -10,6 +10,8 @@ spec:
         ingestionBurstSize: 100
         ingestionRate: 500
         maxGlobalStreamsPerTenant: 100000
+        perStreamRateLimit: 6
+        perStreamRateLimitBurst: 30
   tenants:
     mode: openshift-network
   managementState: Managed

--- a/scripts/loki/lokistack-1x-small.yaml
+++ b/scripts/loki/lokistack-1x-small.yaml
@@ -10,6 +10,8 @@ spec:
         ingestionBurstSize: 100
         ingestionRate: 500
         maxGlobalStreamsPerTenant: 100000
+        perStreamRateLimit: 6
+        perStreamRateLimitBurst: 30
   tenants:
     mode: openshift-network
   managementState: Managed


### PR DESCRIPTION
[NETOBSERV-717](https://issues.redhat.com/browse/NETOBSERV-717) adds new LokiStack config options that we want to take advantage of for our performance testing.

Also updating the README with the new changes to the NOPE tool.