### PR TITLE
Router perf no jq

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -309,6 +309,7 @@ pipeline {
                                 echo "replace tolerancy to $TOLERANCY in mb-tolerancy-rules.yaml"
                                 sed -i "s/tolerancy:.*/tolerancy: $TOLERANCY/" mb-tolerancy-rules.yaml
                             fi
+                            pip install jq
                             ./ingress-performance.sh |& tee "ingress_router.out"
                             ! grep "Benchmark comparison failed" ingress_router.out
                             '''


### PR DESCRIPTION
Don't have jq installed in jenkins system by default, installing jq with pip 

```
08-09 10:29:45.149  jq: error (at <stdin>:1): Cannot iterate over null (null)
08-09 10:29:45.149  + grep 'Benchmark comparison failed' ingress_router.out
08-09 10:29:45.154  [Pipeline] archiveArtifacts
08-09 10:29:45.157  Archiving artifacts
08-09 10:29:45.167  Recording fingerprints
```

Job that got past that step: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/paige-e2e-multibranch/job/router-perf/39/console