### PR TITLE
Kube burner hard coded version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,7 +80,12 @@ pipeline {
           defaultValue: '', 
           description: 'Optional image to help get must-gather information on non default areas. See <a href="https://docs.openshift.com/container-platform/4.12/support/gathering-cluster-data.html">docs</a> for more information and options.'
         )
-      string(
+        string(
+            name: "KUBE_BURNER_URL"
+            defaultValue: "https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.17.3/kube-burner-0.17.3-Linux-x86_64.tar.gz"
+            description: "Url of the kube-burner tar file to use to load the cluster"
+        )
+        string(
           name: 'VARIABLE',
           defaultValue: '1000', 
           description: '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,8 +81,8 @@ pipeline {
           description: 'Optional image to help get must-gather information on non default areas. See <a href="https://docs.openshift.com/container-platform/4.12/support/gathering-cluster-data.html">docs</a> for more information and options.'
         )
         string(
-            name: "KUBE_BURNER_URL"
-            defaultValue: "https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.17.3/kube-burner-0.17.3-Linux-x86_64.tar.gz"
+            name: "KUBE_BURNER_URL",
+            defaultValue: "https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.17.3/kube-burner-0.17.3-Linux-x86_64.tar.gz",
             description: "Url of the kube-burner tar file to use to load the cluster"
         )
         string(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
       )
       choice(
           name: 'WORKLOAD',
-          choices: ["cluster-density", "cluster-density-ms","node-density", "node-density-heavy","node-density-cni","node-density-cni-networkpolicy","pod-density", "pod-density-heavy","concurrent-builds","pods-service-route","networkpolicy-case1","networkpolicy-case2","networkpolicy-case3"],
+          choices: ["cluster-density", "cluster-density-ms","node-density", "node-density-heavy","node-density-cni","node-density-cni-networkpolicy","concurrent-builds","pods-service-route","networkpolicy-case1","networkpolicy-case2","networkpolicy-case3"],
           description: 'Type of kube-burner job to run'
       )
       booleanParam(


### PR DESCRIPTION
The latest kube-burner version that is set in e2e-benchmarking does not support the current config files that are in e2e-benchmarking/workloads/kube-burner 
Need to hard set the specific version of kube-burner that still works 

Used in conjunction with pr in https://github.com/cloud-bulldozer/e2e-benchmarking/pull/609

Passing job https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/paige-e2e-multibranch/job/kube-burner/253/console