### PR TITLE
Adding jq as install

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -283,6 +283,7 @@ pipeline {
                         set -o pipefail
  
                         cd workloads/kube-burner-ocp-wrapper
+                        pip install jq
                         if [[ $CHURN == true ]]; then
                             echo "churn true"
                             export EXTRA_FLAGS="--churn=true --churn-delay=${CHURN_DELAY} --churn-duration=${CHURN_DURATION} --churn-percent=${CHURN_PERCENT}"
@@ -330,7 +331,7 @@ pipeline {
                     python3.9 -m virtualenv venv3
                     source venv3/bin/activate
                     python --version
-                    python -m pip install -r $WORKSPACE/helpful_scripts/scripts/requirements.txt
+                    python -m pip install -r $WORKSPACE/helpful_scripts/scripts/requirements.txt 
                     python $WORKSPACE/helpful_scripts/scripts/sandman.py --file $WORKSPACE/workload-artifacts/workloads/**/*.out
                 """)
                 // fail pipeline if Mr. Sandman run failed, continue otherwise

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -331,7 +331,7 @@ pipeline {
                     python3.9 -m virtualenv venv3
                     source venv3/bin/activate
                     python --version
-                    python -m pip install -r $WORKSPACE/helpful_scripts/scripts/requirements.txt 
+                    python -m pip install -r $WORKSPACE/helpful_scripts/scripts/requirements.txt
                     python $WORKSPACE/helpful_scripts/scripts/sandman.py --file $WORKSPACE/workload-artifacts/workloads/**/*.out
                 """)
                 // fail pipeline if Mr. Sandman run failed, continue otherwise


### PR DESCRIPTION
Missing jq to be able to iterate in e2e-benchmarking

Error: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/kube-burner-ocp/108/console

```
08-14 12:30:54.148  + ./run.sh
08-14 12:30:54.148  + tee kube-burner-ocp.out
08-14 12:30:54.148  jq: error (at <stdin>:1): Cannot iterate over null (null)
```