### PR TITLE
update code to check-rosa-upgrade

### DIFF
--- a/upgrade_scripts/check-rosa-upgrade.sh
+++ b/upgrade_scripts/check-rosa-upgrade.sh
@@ -3,7 +3,10 @@ source ./common.sh
 upgrade_pass=True
 
 SECONDS=0
+TARGET_BUILD=${TARGET_BUILD:=""}
 export PYTHONUNBUFFERED=1
+echo TARGET_RELEASES is $TARGET_RELEASES
+target_version_prefix=${TARGET_RELEASES}
 python3 -c "import check_upgrade; check_upgrade.check_upgrade('$target_version_prefix')"
 duration=$SECONDS
 echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."

--- a/upgrade_scripts/check_upgrade.py
+++ b/upgrade_scripts/check_upgrade.py
@@ -102,9 +102,18 @@ def wait_for_mcp_upgrade(wait_num=90):
         print("MCP workers are updating, waiting 20 seconds")
         counter += 1
         if counter >= wait_num:
+            print("#"*118)
             return_code, node_not_ready = invoke("oc get nodes | grep 'NotReady\|SchedulingDisabled'")
             print("Node list: " + str(node_not_ready))
+            print("-"*118)
+            return_code, mcp_status = invoke("oc get mcp")
+            print("oc get mcp: " + str(mcp_status))
+            print("-"*118)
+            return_code, describe_mcp = invoke("for mcpname in `oc get mcp -oname`;do oc describe $mcpname;echo;echo '-----------------------------------------------------------'; done")
+            print("oc describe mcp mcpname: " + str(describe_mcp))
+            print("-"*118)
             print("ERROR, mcp workers are still updating after 30 minutes")
+            print("#"*118)
             sys.exit(1)
 
 def pause_machinepool_worker(pause_val):


### PR DESCRIPTION
Update code to add correct version to check-version  and increase the timeout of checking mcp and also capture mcp state if mcp isn't readay. 

Prow CI logs
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_release/41663/rehearse-41663-periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-rosa-candidate-4.13-loaded-upgrade-from-4.12-perfscale-rosa-multiaz-24nodes-stage-loaded-upgrade413/1693813462578237440/artifacts/perfscale-rosa-multiaz-24nodes-stage-loaded-upgrade413/openshift-qe-rosa-upgrade-postcheck/build-log.txt

Jenkins Job Logs:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/liqcui-e2e-benchmarking-multibranch-pipeline/job/upgrade/97/console
