### PR TITLE
Ingress perf infra check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -211,8 +211,16 @@ pipeline {
                             oc config view
                             oc projects
                             ls -ls ~/.kube/
-                            env
                             cd workloads/ingress-perf
+
+                            current_infra_nodes=$(oc get nodes -l node-role.kubernetes.io/infra="" --no-headers | wc -l | xargs)
+                            if [[ $current_infra_nodes < 2 ]]; then
+                                echo "Be sure to add infra nodes to your cluster before running ingress-perf" >> "ingress_perf.out"
+                                exit 1
+                            fi
+
+                            env
+                            
                             ./run.sh |& tee "ingress_perf.out"
                             ! egrep -i "lower than baseline|higher than baseline|error|fail" ingress_perf.out
                             '''


### PR DESCRIPTION
Adding in infra node check because ingress perf requires it

No infra nodes: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/paige-e2e-multibranch/job/ingress-perf/10/console

infra nodes on cluster -> started to run test: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/paige-e2e-multibranch/job/ingress-perf/11/console