### PR TITLE
Kube burner ocp specific version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -183,7 +183,7 @@ pipeline {
       )
       string(
           name: 'KUBE_BURNER_VERSION',
-          defaultValue: 'v1.7.6',
+          defaultValue: '1.7.6',
           description: 'You can change this to point to an older kube-burner version if needed.'
       )
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,6 +181,11 @@ pipeline {
           defaultValue: 'master',
           description: 'You can change this to point to a branch on your fork if needed.'
       )
+      string(
+          name: 'KUBE_BURNER_VERSION',
+          defaultValue: 'v1.7.6',
+          description: 'You can change this to point to an older kube-burner version if needed.'
+      )
   }
   stages {  
     stage('Scale up cluster') {


### PR DESCRIPTION
Setting specific kube burner version to try to get around issue: https://github.com/cloud-bulldozer/e2e-benchmarking/issues/619

https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/paige-e2e-multibranch/job/kube-burner-ocp/83/console