### PR TITLE
Duration not an option in older (4.10) version

### DIFF
--- a/openshift-qe-move-pods-infra-commands.sh
+++ b/openshift-qe-move-pods-infra-commands.sh
@@ -27,7 +27,7 @@ function set_storage_class() {
 }
 
 function wait_for_prometheus_status() {
-    token=$(oc sa get-token -n openshift-monitoring prometheus-k8s || oc sa new-token -n openshift-monitoring prometheus-k8s || oc create token -n openshift-monitoring prometheus-k8s --duration=6h)
+    token=$(oc create token -n openshift-monitoring prometheus-k8s --duration=6h || oc sa get-token -n openshift-monitoring prometheus-k8s || oc sa new-token -n openshift-monitoring prometheus-k8s)
 
     URL=https://$(oc get route -n openshift-monitoring prometheus-k8s -o jsonpath="{.spec.host}")
     sleep 30

--- a/openshift-qe-move-pods-infra-commands.sh
+++ b/openshift-qe-move-pods-infra-commands.sh
@@ -27,7 +27,7 @@ function set_storage_class() {
 }
 
 function wait_for_prometheus_status() {
-    token=$(oc create token -n openshift-monitoring prometheus-k8s --duration=6h)
+    token=$(oc sa get-token -n openshift-monitoring prometheus-k8s || oc sa new-token -n openshift-monitoring prometheus-k8s || oc create token -n openshift-monitoring prometheus-k8s --duration=6h)
 
     URL=https://$(oc get route -n openshift-monitoring prometheus-k8s -o jsonpath="{.spec.host}")
     sleep 30


### PR DESCRIPTION
In previous versions the "--duration" was not an option in the `oc create` command. Need to other command options for older versions 

Can see this command in use: https://github.com/cloud-bulldozer/e2e-benchmarking/blob/f7641e36cc07271205be4cc7e15b0c2097a1f7ac/workloads/network-perf/common.sh#L13

https://issues.redhat.com/browse/OCPQE-16652