### PR TITLE
adding kube burner version to install

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,6 +70,11 @@ pipeline {
                   </p>'''
     )
     string(
+        name: 'KUBE_BURNER_VERSION',
+        defaultValue: '1.7.6',
+        description: 'You can change this to point to an older kube-burner version if needed.'
+    )
+    string(
         name: 'SVT_REPO', 
         defaultValue:'https://github.com/openshift/svt', 
         description:'''<p>


### PR DESCRIPTION
Want to set a specific kube-burner version to avoid issues getting latest version 


https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/regression-test/379/console

Similar functionality was added for kube-burner and [kube-burner-ocp](https://github.com/openshift-qe/ocp-qe-perfscale-ci/pull/511)