### PR TITLE
Fix bug with NOPE tool incorrectly parsing workload

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -903,7 +903,7 @@ pipeline {
                                         println('Successfully uploaded new baseline to Elasticsearch :)')
                                         currentBuild.description += "New Baseline Upload: <b>SUCCESS</b><br/>"
                                     }
-                                }                            
+                                }
                             }
                         }
                     }

--- a/scripts/nope.py
+++ b/scripts/nope.py
@@ -47,6 +47,7 @@ JENKINS_JOB = None
 JENKINS_BUILD = None
 JENKINS_SERVER = None
 UUID = None
+SUPPORTED_WORKLOADS = ['node-density-heavy', 'router-perf', 'cluster-density', 'cluster-density-v2']
 
 # elasticsearch constants
 ES_URL = 'search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com'
@@ -263,11 +264,14 @@ def get_jenkins_env_info():
             del param['_class']
             if param.get('name') == 'VARIABLE':
                 info['variable'] = int(param.get('value'))
-            # if workload is not explicitly set in Jenkins such as with router-perf, take it from the job name 
             if param.get('name') == 'WORKLOAD':
                 info['workload'] = str(param.get('value'))
-            else:
-                info['workload'] = JENKINS_JOB.split('/')[-1]
+        # if workload is not explicitly set in Jenkins such as with router-perf, take it from the job name 
+        if info.get('workload') is None:
+            info['workload'] = JENKINS_JOB.split('/')[-1]
+        # check if a valid workload has been parsed
+        if info['workload'] not in SUPPORTED_WORKLOADS:
+            raise Exception(f"{info['workload']} is not in the list of supported workloads: {SUPPORTED_WORKLOADS}")
 
     except Exception as e:
         logging.error(f"Failed to collect Jenkins build parameter info: {e}")


### PR DESCRIPTION
So this was a fun one I became aware of while uploading the 1.4 baselines - in #493 I update this piece of NOPE code to the following:
```python
        for param in build_parameters:
            del param['_class']
            if param.get('name') == 'VARIABLE':
                info['variable'] = int(param.get('value'))
            # if workload is not explicitly set in Jenkins such as with router-perf, take it from the job name 
            if param.get('name') == 'WORKLOAD':
                info['workload'] = str(param.get('value'))
            else:
                info['workload'] = JENKINS_JOB.split('/')[-1]
```
However, this led to all `kube-burner-ocp` jobs (`node-density-heavy` and `cluster-density-v2`) parsing out `kube-burner-ocp` for the workload rather than the actual workload from the `WORKLOAD` variable - but why?

```text
              {'_class': 'hudson.model.StringParameterValue', 'name': 'WORKLOAD', 'value': 'node-density-heavy'
              },
              {'_class': 'hudson.model.BooleanParameterValue', 'name': 'CLEANUP', 'value': True
              },
              {'_class': 'hudson.model.BooleanParameterValue', 'name': 'CERBERUS_CHECK', 'value': True
              },
              {'_class': 'hudson.model.BooleanParameterValue', 'name': 'MUST_GATHER', 'value': True
              },
              {'_class': 'hudson.model.StringParameterValue', 'name': 'IMAGE', 'value': 'quay.io/netobserv/must-gather'
              },
              {'_class': 'hudson.model.StringParameterValue', 'name': 'VARIABLE', 'value': '200'
              },
```
Above you see an excerpt from the `build_parameters` object we are iterating over - due to the previous structure of the code, whenever we hit anything that wasn't the `WORKLOAD` field, the `info[workload]` entry would be updated to the job split name, which normally should only be done for `router-perf` since that job doesn't utilize the `WORKLOAD` field at all.

This PR fixes compatibility for all job types, and adds an additional check to ensure the workload we are parsing is valid based off our testing scenarios.