### PR TITLE
Further increased Loki perStreamRateLimit

### DIFF
--- a/scripts/loki/lokistack-1x-exsmall.yaml
+++ b/scripts/loki/lokistack-1x-exsmall.yaml
@@ -10,8 +10,8 @@ spec:
         ingestionBurstSize: 100
         ingestionRate: 500
         maxGlobalStreamsPerTenant: 100000
-        perStreamRateLimit: 6
-        perStreamRateLimitBurst: 30
+        perStreamRateLimit: 9
+        perStreamRateLimitBurst: 45
   tenants:
     mode: openshift-network
   managementState: Managed

--- a/scripts/loki/lokistack-1x-medium.yaml
+++ b/scripts/loki/lokistack-1x-medium.yaml
@@ -10,8 +10,8 @@ spec:
         ingestionBurstSize: 100
         ingestionRate: 500
         maxGlobalStreamsPerTenant: 100000
-        perStreamRateLimit: 6
-        perStreamRateLimitBurst: 30
+        perStreamRateLimit: 9
+        perStreamRateLimitBurst: 45
   tenants:
     mode: openshift-network
   managementState: Managed

--- a/scripts/loki/lokistack-1x-small.yaml
+++ b/scripts/loki/lokistack-1x-small.yaml
@@ -10,8 +10,8 @@ spec:
         ingestionBurstSize: 100
         ingestionRate: 500
         maxGlobalStreamsPerTenant: 100000
-        perStreamRateLimit: 6
-        perStreamRateLimitBurst: 30
+        perStreamRateLimit: 9
+        perStreamRateLimitBurst: 45
   tenants:
     mode: openshift-network
   managementState: Managed


### PR DESCRIPTION
Hit `429` error again in `router-perf` - cluster still has a lot of resource capacity so going to increase this limit once more