### PR TITLE
Timestamp change for kube burner 

### DIFF
--- a/scripts/sandman.py
+++ b/scripts/sandman.py
@@ -27,10 +27,10 @@ def main():
 
     # initialize regexs based on file type
     if "kube-burner-ocp" in WORKLOAD_OUT_FILE:
-        base_regex = 'time="(\d+-\d+-\d+ \d+:\d+:\d+)".*'
+        base_regex = 'time="(\d+-\d+-\d+T\d+:\d+:\d+Z)".*'
         starttime_regex = base_regex + 'Starting'
         endtime_regex = base_regex + 'Exiting'
-        strptime_filter = '%Y-%m-%d %H:%M:%S'
+        strptime_filter = '%Y-%m-%dT%H:%M:%SZ'
         workload_regex = 'Job '
         workload_end_regex = ':'
         uuid_regex = 'UUID (.*)"'


### PR DESCRIPTION
In the newest verison of kube burner the timestamps are being updated to a different version 

https://github.com/cloud-bulldozer/kube-burner/commit/9cc9482551de01e9458ec9b2d538b24fcac82078

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.14-nightly-x86-ovnic-ocp-qe-perfscale-aws-cni-120ppn-test-252nodes-scale-ovnic/1706610220391731200
Took the output and was able to run successfully with these changes