### PR TITLE
Removing kube burner version and read new index file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -301,6 +301,8 @@ pipeline {
                         export GC=${CLEANUP}
                         ./run.sh |& tee "kube-burner-ocp.out"
 
+                        ls /tmp
+
                     ''')
                     archiveArtifacts(
                         artifacts: 'workloads/kube-burner-ocp-wrapper/kube-burner-ocp.out',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -301,11 +301,20 @@ pipeline {
                         export GC=${CLEANUP}
                         ./run.sh |& tee "kube-burner-ocp.out"
 
-                        ls /tmp
+                        folder_name=$(ls -t -d /tmp/*/ | HEAD -n 1)
+                        file_loc=$folder_name"*"
+                        cp $file_loc workloads/kube-burner-ocp-wrapper/
+
 
                     ''')
                     archiveArtifacts(
                         artifacts: 'workloads/kube-burner-ocp-wrapper/kube-burner-ocp.out',
+                        allowEmptyArchive: true,
+                        fingerprint: true
+                    )
+
+                    archiveArtifacts(
+                        artifacts: 'workloads/kube-burner-ocp-wrapper/*.json',
                         allowEmptyArchive: true,
                         fingerprint: true
                     )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -301,7 +301,7 @@ pipeline {
                         export GC=${CLEANUP}
                         ./run.sh |& tee "kube-burner-ocp.out"
                         ls /tmp
-                        folder_name=$(ls -t -d /tmp/*/ | HEAD -n 1)
+                        folder_name=$(ls -t -d /tmp/*/ | head -1)
                         file_loc=$folder_name"*"
                         cp $file_loc workloads/kube-burner-ocp-wrapper/
 
@@ -319,6 +319,11 @@ pipeline {
                         fingerprint: true
                     )
 
+                    workloadInfo = readJSON file: "workloads/kube-burner-ocp-wrapper/*.json"
+                    workloadInfo.each { env.setProperty(it.key.toUpperCase(), it.value) }
+                    // update build description fields
+                    // UUID
+                    currentBuild.description += "\n<b>UUID:</b> ${env.UUID}<br/>"
                     if (RETURNSTATUS.toInteger() == 0) {
                         status = "PASS"
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -332,47 +332,6 @@ pipeline {
                     }
                 }
             }
-            checkout([
-                $class: 'GitSCM',
-                branches: [[name: 'main' ]],
-                userRemoteConfigs: [[url: "https://github.com/openshift-qe/ocp-qe-perfscale-ci" ]],
-                extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'helpful_scripts']]
-            ])
-            copyArtifacts(
-                fingerprintArtifacts: true, 
-                projectName: JOB_NAME,
-                selector: specific(JENKINS_JOB_NUMBER),
-                target: 'workload-artifacts'
-            )
-            script {
-                // run Mr. Sandman
-                returnCode = sh(returnStatus: true, script: """
-                    python3.9 --version
-                    python3.9 -m pip install virtualenv
-                    python3.9 -m virtualenv venv3
-                    source venv3/bin/activate
-                    python --version
-                    python -m pip install -r $WORKSPACE/helpful_scripts/scripts/requirements.txt
-                    python $WORKSPACE/helpful_scripts/scripts/sandman.py --file $WORKSPACE/workload-artifacts/workloads/**/*.out
-                """)
-                // fail pipeline if Mr. Sandman run failed, continue otherwise
-                if (returnCode.toInteger() != 0) {
-                    error('Mr. Sandman tool failed :(')
-                }
-                else {
-                    println 'Successfully ran Mr. Sandman tool :)'
-                }
-                archiveArtifacts(
-                    artifacts: 'helpful_scripts/data/*',
-                    allowEmptyArchive: true,
-                    fingerprint: true
-                )
-                workloadInfo = readJSON file: "helpful_scripts/data/workload.json"
-                workloadInfo.each { env.setProperty(it.key.toUpperCase(), it.value) }
-                // update build description fields
-                // UUID
-                currentBuild.description += "\n<b>UUID:</b> ${env.UUID}<br/>"
-            }
         }
     }
     stage("Create google sheet") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -303,7 +303,7 @@ pipeline {
                         ls /tmp
                         folder_name=$(ls -t -d /tmp/*/ | head -1)
                         file_loc=$folder_name"*"
-                        cp $file_loc workloads/kube-burner-ocp-wrapper/
+                        cp $file_loc .
 
 
                     ''')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -332,6 +332,47 @@ pipeline {
                     }
                 }
             }
+            checkout([
+                $class: 'GitSCM',
+                branches: [[name: 'main' ]],
+                userRemoteConfigs: [[url: "https://github.com/openshift-qe/ocp-qe-perfscale-ci" ]],
+                extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'helpful_scripts']]
+            ])
+            copyArtifacts(
+                fingerprintArtifacts: true, 
+                projectName: JOB_NAME,
+                selector: specific(JENKINS_JOB_NUMBER),
+                target: 'workload-artifacts'
+            )
+            script {
+                // run Mr. Sandman
+                returnCode = sh(returnStatus: true, script: """
+                    python3.9 --version
+                    python3.9 -m pip install virtualenv
+                    python3.9 -m virtualenv venv3
+                    source venv3/bin/activate
+                    python --version
+                    python -m pip install -r $WORKSPACE/helpful_scripts/scripts/requirements.txt
+                    python $WORKSPACE/helpful_scripts/scripts/sandman.py --file $WORKSPACE/workload-artifacts/workloads/**/*.out
+                """)
+                // fail pipeline if Mr. Sandman run failed, continue otherwise
+                if (returnCode.toInteger() != 0) {
+                    error('Mr. Sandman tool failed :(')
+                }
+                else {
+                    println 'Successfully ran Mr. Sandman tool :)'
+                }
+                archiveArtifacts(
+                    artifacts: 'helpful_scripts/data/*',
+                    allowEmptyArchive: true,
+                    fingerprint: true
+                )
+                workloadInfo = readJSON file: "helpful_scripts/data/workload.json"
+                workloadInfo.each { env.setProperty(it.key.toUpperCase(), it.value) }
+                // update build description fields
+                // UUID
+                currentBuild.description += "\n<b>UUID:</b> ${env.UUID}<br/>"
+            }
         }
     }
     stage("Create google sheet") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -300,7 +300,7 @@ pipeline {
                         fi
                         export GC=${CLEANUP}
                         ./run.sh |& tee "kube-burner-ocp.out"
-
+                        ls /tmp
                         folder_name=$(ls -t -d /tmp/*/ | HEAD -n 1)
                         file_loc=$folder_name"*"
                         cp $file_loc workloads/kube-burner-ocp-wrapper/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -186,11 +186,6 @@ pipeline {
           defaultValue: 'master',
           description: 'You can change this to point to a branch on your fork if needed.'
       )
-      string(
-          name: 'KUBE_BURNER_VERSION',
-          defaultValue: '1.7.6',
-          description: 'You can change this to point to an older kube-burner version if needed.'
-      )
   }
   stages {  
     stage('Scale up cluster') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -314,12 +314,12 @@ pipeline {
                     )
 
                     archiveArtifacts(
-                        artifacts: 'workloads/kube-burner-ocp-wrapper/*.json',
+                        artifacts: 'workloads/kube-burner-ocp-wrapper/index_data.json',
                         allowEmptyArchive: true,
                         fingerprint: true
                     )
 
-                    workloadInfo = readJSON file: "workloads/kube-burner-ocp-wrapper/*.json"
+                    workloadInfo = readJSON file: "workloads/kube-burner-ocp-wrapper/index_data.json"
                     workloadInfo.each { env.setProperty(it.key.toUpperCase(), it.value) }
                     // update build description fields
                     // UUID


### PR DESCRIPTION
E2e benchmarking no longer gets the latest kube-burner version, want to keep up to dat with what is in prow 

this would have to go before: https://github.com/openshift-qe/ocp-qe-perfscale-ci/pull/526