### PR TITLE
[must-gather] No longer rely on quay.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
               spec:
                 containers:
                 - name: "jnlp"
-                  image: "quay.io/openshift-qe-optional-operators/cucushift:${JENKINS_AGENT_LABEL}-rhel8"
+                  image: "image-registry.openshift-image-registry.svc:5000/aos-qe-ci/cucushift:${JENKINS_AGENT_LABEL}-rhel8"
                   resources:
                     requests:
                       memory: "8Gi"
@@ -55,8 +55,6 @@ pipeline {
                   imagePullPolicy: Always
                   workingDir: "/home/jenkins/ws"
                   tty: true
-                imagePullSecrets:
-                - name: "docker-config-quay.io"
               """.stripIndent()
           }
         }


### PR DESCRIPTION
We've done the same changes in https://gitlab.cee.redhat.com/aosqe/jenkins-jcasc-n/-/merge_requests/1755 on Sep 27, 2023, and it improved the performance of Jenkins and OCP cluster.
Also with this change, we are not affected by quay.io outage.