### PR TITLE
[kube-burner] No longer rely on quay.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -258,7 +258,7 @@ pipeline {
               spec:
                 containers:
                 - name: "jnlp"
-                  image: "quay.io/openshift-qe-optional-operators/cucushift:${JENKINS_AGENT_LABEL}-rhel8"
+                  image: "image-registry.openshift-image-registry.svc:5000/aos-qe-ci/cucushift:${JENKINS_AGENT_LABEL}-rhel8"
                   resources:
                     requests:
                       memory: "8Gi"
@@ -269,8 +269,6 @@ pipeline {
                   imagePullPolicy: Always
                   workingDir: "/home/jenkins/ws"
                   tty: true
-                imagePullSecrets:
-                - name: "docker-config-quay.io"
               """.stripIndent()
           }
         }


### PR DESCRIPTION
The same as https://github.com/openshift-qe/ocp-qe-perfscale-ci/pull/541