### PR TITLE
[kube-burner-ocp] No longer rely on quay.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -217,7 +217,7 @@ pipeline {
               spec:
                 containers:
                 - name: "jnlp"
-                  image: "quay.io/openshift-qe-optional-operators/cucushift:${JENKINS_AGENT_LABEL}-rhel8"
+                  image: "image-registry.openshift-image-registry.svc:5000/aos-qe-ci/cucushift:${JENKINS_AGENT_LABEL}-rhel8"
                   resources:
                     requests:
                       memory: "8Gi"
@@ -228,8 +228,6 @@ pipeline {
                   imagePullPolicy: Always
                   workingDir: "/home/jenkins/ws"
                   tty: true
-                imagePullSecrets:
-                - name: "docker-config-quay.io"
               """.stripIndent()
           }
         }


### PR DESCRIPTION
The same as https://github.com/openshift-qe/ocp-qe-perfscale-ci/pull/541