### PR TITLE
get upgrade duration

### DIFF
--- a/write_to_sheet/write_helper.py
+++ b/write_to_sheet/write_helper.py
@@ -28,8 +28,8 @@ def get_upgrade_duration():
     all_versions = []
     if return_code == 0:
         version_json = json.loads(version_str)
-        earliesetStartingTime = datetime.max
-        latestCompletiontime = datetime.min
+        earliesetStartingTime = datetime.datetime.max
+        latestCompletiontime = datetime.datetime.min
         for item in version_json['items']:
             lastVersion = True
             counter = 0


### PR DESCRIPTION
Fixing duration issue in upgrade

```
10-17 13:49:41.902  Traceback (most recent call last):
10-17 13:49:41.902    File "<string>", line 1, in <module>
10-17 13:49:41.902    File "/home/jenkins/ws/workspace/_pipeline_write-scale-ci-results/write_to_sheet/write_loaded_results.py", line 22, in write_to_sheet
10-17 13:49:41.902      duration, versions = write_helper.get_upgrade_duration()
10-17 13:49:41.902    File "/home/jenkins/ws/workspace/_pipeline_write-scale-ci-results/write_to_sheet/write_helper.py", line 31, in get_upgrade_duration
10-17 13:49:41.902      earliesetStartingTime = datetime.max
10-17 13:49:41.902  AttributeError: module 'datetime' has no attribute 'max'
```