### PR TITLE
update code to extend the timeout of checking upgrade

### DIFF
--- a/upgrade_scripts/common.sh
+++ b/upgrade_scripts/common.sh
@@ -146,7 +146,7 @@ function capture_failed_pods_before_upgrade(){
   #Save the failed job before upgrade and make sure new failed job caused by upgrade,ignore installer, build error
   echo "Capture failed pods before upgrade OCP"
   echo "####################################################################################"
-  oc get pods -A| grep -v -E 'Running|Completed|installer|build'| awk '(NF=NF-2) 1'>/tmp/upgrade-before-failed-pods.txt
+  oc get pods -A| grep -v -E 'Running|Completed|installer|build|Terminating'| awk '(NF=NF-2) 1'>/tmp/upgrade-before-failed-pods.txt
 }
 
 function capture_failed_pods_after_upgrade(){
@@ -154,7 +154,7 @@ function capture_failed_pods_after_upgrade(){
   echo "Capture failed pods after upgrade OCP, No messages means no errors"
   echo "####################################################################################"
   #Adding re-try steps to avoid temp failed pod
-  oc get pods -A| grep -v -E 'Running|Completed|installer|build'| awk '(NF=NF-2) 1'>/tmp/upgrade-after-failed-pods.txt
+  oc get pods -A| grep -v -E 'Running|Completed|installer|build|Terminating'| awk '(NF=NF-2) 1'>/tmp/upgrade-after-failed-pods.txt
   cat /tmp/upgrade-before-failed-pods.txt /tmp/upgrade-after-failed-pods.txt | sort | uniq -u>/tmp/new-failed-pods.txt
   init_retry=1
   max_retry=30

--- a/upgrade_scripts/common.sh
+++ b/upgrade_scripts/common.sh
@@ -146,7 +146,7 @@ function capture_failed_pods_before_upgrade(){
   #Save the failed job before upgrade and make sure new failed job caused by upgrade,ignore installer, build error
   echo "Capture failed pods before upgrade OCP"
   echo "####################################################################################"
-  oc get pods -A| grep -v -E 'Running|Completed|installer|build|Terminating'| awk '(NF=NF-2) 1'>/tmp/upgrade-before-failed-pods.txt
+  oc get pods -A| grep -v -E 'Running|Completed|installer|build'| awk '(NF=NF-2) 1'>/tmp/upgrade-before-failed-pods.txt
 }
 
 function capture_failed_pods_after_upgrade(){
@@ -154,7 +154,7 @@ function capture_failed_pods_after_upgrade(){
   echo "Capture failed pods after upgrade OCP, No messages means no errors"
   echo "####################################################################################"
   #Adding re-try steps to avoid temp failed pod
-  oc get pods -A| grep -v -E 'Running|Completed|installer|build|Terminating'| awk '(NF=NF-2) 1'>/tmp/upgrade-after-failed-pods.txt
+  oc get pods -A| grep -v -E 'Running|Completed|installer|build'| awk '(NF=NF-2) 1'>/tmp/upgrade-after-failed-pods.txt
   cat /tmp/upgrade-before-failed-pods.txt /tmp/upgrade-after-failed-pods.txt | sort | uniq -u>/tmp/new-failed-pods.txt
   init_retry=1
   max_retry=30

--- a/upgrade_scripts/upgrade.sh
+++ b/upgrade_scripts/upgrade.sh
@@ -155,8 +155,10 @@ do
   SECONDS=0
   CONSOLE_LAST_LINE="$($upgrade_line)"
   echo $CONSOLE_LAST_LINE
+  export UPGRADE_WAIT_NUM=${UPGRADE_WAIT_NUM:-300}
   export PYTHONUNBUFFERED=1
-  python3 -c "import check_upgrade; check_upgrade.check_upgrade('$target_version_prefix')"
+  echo "Specify UPGRADE_WAIT_NUM is $UPGRADE_WAIT_NUM"
+  python3 -c "import check_upgrade; check_upgrade.check_upgrade('$target_version_prefix',wait_num=$UPGRADE_WAIT_NUM)"
   duration=$SECONDS
   echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
   sleep 30

--- a/upgrade_scripts/upgrade.sh
+++ b/upgrade_scripts/upgrade.sh
@@ -59,7 +59,8 @@ echo "force $enable_force"
 echo "scale $scale"
 echo "target version $taget_build_arr"
 echo "eus $eus"
-
+#wait 120s for all pod get ready
+sleep 120
 capture_failed_pods_before_upgrade
 python3 -c "import check_upgrade; check_upgrade.set_max_unavailable($maxUnavail)"
 echo ARCH_TYPE is $ARCH_TYPE
@@ -183,5 +184,7 @@ if [ "X$scale" == "Xtrue" ]; then
   oc scale --replicas=$machine_replicas -n openshift-machine-api $machine_name
   python3 -c "import check_upgrade; check_upgrade.wait_for_replicas('$machine_replicas','$machine_name')"
 fi
+#wait 120s for all pod get ready
+sleep 120
 capture_failed_pods_after_upgrade
 exit 0 #upgrade succ and post-check succ


### PR DESCRIPTION
update code to extend the timeout of checking upgrade and ignore terminating pod
Jenkins Logs:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/liqcui-e2e-benchmarking-multibranch-pipeline/job/loaded-upgrade/110/console

Adding UPGRADE_WAIT_NUM to extend the timeout of checking check_upgrade.check_upgrade 

because ibmcloud will take more time to complete loaded upgrade, so we need to increase the timeout of check_upgrade.check_upgrade, the default value 300 isn't enough