### PR TITLE
Remove explicit namespace from Loki config in flowcollector

### DIFF
--- a/scripts/netobserv/flows_v1beta2_flowcollector.yaml
+++ b/scripts/netobserv/flows_v1beta2_flowcollector.yaml
@@ -99,7 +99,6 @@ spec:
     mode: LokiStack
     lokiStack:
       name: lokistack
-      namespace: netobserv
     batchWait: 1s
     batchSize: 10485760
     minBackoff: 1s


### PR DESCRIPTION
New `lokistack` mode does not require explicit namespace to be set - since we have always used the default (`netobserv`) namespace anyway, we can remove that from our flowcollector CRD.

Tested here: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/nweinber-e2e-benchmarking-multibranch-pipeline/job/netobserv-perf-tests/460/