### PR TITLE
Remove Mr. Sandman entirely

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -343,35 +343,6 @@ pipeline {
                 selector: specific(JENKINS_JOB_NUMBER),
                 target: 'workload-artifacts'
             )
-            script {
-                // run Mr. Sandman
-                returnCode = sh(returnStatus: true, script: """
-                    python3.9 --version
-                    python3.9 -m pip install virtualenv
-                    python3.9 -m virtualenv venv3
-                    source venv3/bin/activate
-                    python --version
-                    python -m pip install -r $WORKSPACE/helpful_scripts/scripts/requirements.txt
-                    python $WORKSPACE/helpful_scripts/scripts/sandman.py --file $WORKSPACE/workload-artifacts/workloads/**/*.out
-                """)
-                // fail pipeline if Mr. Sandman run failed, continue otherwise
-                if (returnCode.toInteger() != 0) {
-                    error('Mr. Sandman tool failed :(')
-                }
-                else {
-                    println 'Successfully ran Mr. Sandman tool :)'
-                }
-                archiveArtifacts(
-                    artifacts: 'helpful_scripts/data/*',
-                    allowEmptyArchive: true,
-                    fingerprint: true
-                )
-                workloadInfo = readJSON file: "helpful_scripts/data/workload.json"
-                workloadInfo.each { env.setProperty(it.key.toUpperCase(), it.value) }
-                // update build description fields
-                // UUID
-                currentBuild.description += "\n<b>UUID:</b> ${env.UUID}<br/>"
-            }
         }
     }
     stage("Create google sheet") {


### PR DESCRIPTION
Since https://github.com/openshift-qe/ocp-qe-perfscale-ci/pull/570 NetObserv team is no longer using Mr. Sandman - if there is no need from the PerfScale team to keep this we can remove it from the `kube-burner-ocp` pipeline