### PR TITLE
Add in final comparison stats with 'zero' values

### DIFF
--- a/scripts/queries/netobserv_touchstone_tolerancy_config.json
+++ b/scripts/queries/netobserv_touchstone_tolerancy_config.json
@@ -139,6 +139,39 @@
             },
             {
                 "filter": {
+                    "metric_name.keyword": "nFlowsErroredTotals"
+                },
+                "buckets": [
+                    "metric_name.keyword"
+                ],
+                "aggregations": {
+                    "value": [
+                        "max"
+                    ]
+                }
+            },
+            {
+                "filter": {
+                    "metric_name.keyword": "nFlowsErroredPerMinuteTotals"
+                },
+                "buckets": [
+                    "metric_name.keyword"
+                ],
+                "aggregations": {
+                    "value": [
+                        {
+                            "percentiles": {
+                                "percents": [
+                                    90
+                                ]
+                            }
+                        },
+                        "avg"
+                    ]
+                }
+            },
+            {
+                "filter": {
                     "metric_name.keyword": "lokiRecordsWritten"
                 },
                 "buckets": [
@@ -153,6 +186,39 @@
             {
                 "filter": {
                     "metric_name.keyword": "lokiRecordsWrittenPerMinute"
+                },
+                "buckets": [
+                    "metric_name.keyword"
+                ],
+                "aggregations": {
+                    "value": [
+                        {
+                            "percentiles": {
+                                "percents": [
+                                    90
+                                ]
+                            }
+                        },
+                        "avg"
+                    ]
+                }
+            },
+            {
+                "filter": {
+                    "metric_name.keyword": "lokiRecordsDropped"
+                },
+                "buckets": [
+                    "metric_name.keyword"
+                ],
+                "aggregations": {
+                    "value": [
+                        "max"
+                    ]
+                }
+            },
+            {
+                "filter": {
+                    "metric_name.keyword": "lokiRecordsDroppedPerMinute"
                 },
                 "buckets": [
                     "metric_name.keyword"

--- a/scripts/queries/netobserv_touchstone_tolerancy_rules.yaml
+++ b/scripts/queries/netobserv_touchstone_tolerancy_rules.yaml
@@ -5,11 +5,23 @@
 - json_path: ["metric_name", "nFlowsProcessedPerMinuteTotals", "metric_name", "*", "avg(value)"]
   tolerancy: -10
   max_failures: 0
+- json_path: ["metric_name", "nFlowsErroredTotals", "metric_name", "*", "max(value)"]
+  tolerancy: -1
+  max_failures: 0
+- json_path: ["metric_name", "nFlowsErroredPerMinuteTotals", "metric_name", "*", "avg(value)"]
+  tolerancy: -1
+  max_failures: 0
 - json_path: ["metric_name", "lokiRecordsWritten", "metric_name", "*", "max(value)"]
-  tolerancy: 2
+  tolerancy: -10
   max_failures: 0
 - json_path: ["metric_name", "lokiRecordsWrittenPerMinute", "metric_name", "*", "avg(value)"]
-  tolerancy: 2
+  tolerancy: -10
+  max_failures: 0
+- json_path: ["metric_name", "lokiRecordsDropped", "metric_name", "*", "max(value)"]
+  tolerancy: -1
+  max_failures: 0
+- json_path: ["metric_name", "lokiRecordsDroppedPerMinute", "metric_name", "*", "avg(value)"]
+  tolerancy: -1
   max_failures: 0
 # CPU totals
 - json_path: ["metric_name", "cpuFLPTotals", "metric_name", "*", "avg(value)"]


### PR DESCRIPTION
Part of [NETOBSERV-1543](https://issues.redhat.com/browse/NETOBSERV-1543)

Now that https://github.com/cloud-bulldozer/benchmark-comparison/pull/76 is in we can begin adding metrics where we typically see a value of '0' to our Touchstone Comparsion, which will allow us to track errored and dropped flows more explicitly  

Tested locally with Touchstone below:
```bash
[nathan@nathan-redhat netobserv-qe-scripts (crd-dir)]$ ./touchstone_compare.sh 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff     c9a81e65-64e9-4cb1-84e9-8f0792913882
File ‘netobserv_touchstone_tolerancy_config.json’ already there; not retrieving.

File ‘netobserv_touchstone_tolerancy_rules.yaml’ already there; not retrieving.

egrep: warning: egrep is obsolescent; using grep -E
+-----------------------+-----------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|      metric_name      |      metric_name      |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+-----------------------+-----------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| nFlowsProcessedTotals | nFlowsProcessedTotals | max(value) |  Fail  |  -75.49%  |              27288832.0              |              6688675.0               |
+-----------------------+-----------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
--
+--------------------------------+--------------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|          metric_name           |          metric_name           |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+--------------------------------+--------------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| nFlowsProcessedPerMinuteTotals | nFlowsProcessedPerMinuteTotals | avg(value) |  Pass  |   2.75%   |          404844.96458333335          |           415993.42578125            |
+--------------------------------+--------------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
--
+---------------------+---------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|     metric_name     |     metric_name     |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+---------------------+---------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| nFlowsErroredTotals | nFlowsErroredTotals | max(value) |  Pass  |   0.00%   |                 0.0                  |                 0.0                  |
+---------------------+---------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
--
+------------------------------+------------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|         metric_name          |         metric_name          |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+------------------------------+------------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| nFlowsErroredPerMinuteTotals | nFlowsErroredPerMinuteTotals | avg(value) |  Pass  |   0.00%   |                 0.0                  |                 0.0                  |
+------------------------------+------------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
--
+--------------------+--------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|    metric_name     |    metric_name     |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+--------------------+--------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| lokiRecordsWritten | lokiRecordsWritten | max(value) |  Fail  |  -75.49%  |              27281852.0              |              6686261.0               |
+--------------------+--------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
--
+-----------------------------+-----------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|         metric_name         |         metric_name         |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+-----------------------------+-----------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| lokiRecordsWrittenPerMinute | lokiRecordsWrittenPerMinute | avg(value) |  Pass  |   2.85%   |              404579.425              |           416129.458984375           |
+-----------------------------+-----------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
--
+--------------------+--------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|    metric_name     |    metric_name     |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+--------------------+--------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| lokiRecordsDropped | lokiRecordsDropped | max(value) |  Pass  |   0.00%   |                 0.0                  |                 0.0                  |
+--------------------+--------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
--
+-----------------------------+-----------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|         metric_name         |         metric_name         |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+-----------------------------+-----------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| lokiRecordsDroppedPerMinute | lokiRecordsDroppedPerMinute | avg(value) |  Pass  |   0.00%   |                 0.0                  |                 0.0                  |
+-----------------------------+-----------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
--
+--------------+--------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| metric_name  | metric_name  |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+--------------+--------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| cpuFLPTotals | cpuFLPTotals | avg(value) |  Pass  |   0.71%   |          1.6973307073116302          |          1.7093896083533764          |
+--------------+--------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
--
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|  metric_name  |  metric_name  |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| cpuEBPFTotals | cpuEBPFTotals | avg(value) |  Pass  |  -1.20%   |          1.9241856733957927          |          1.901170140132308           |
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
--
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|  metric_name  |  metric_name  |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| cpuLokiTotals | cpuLokiTotals | avg(value) |  Pass  |  -13.34%  |          0.400474754969279           |         0.34703495912253857          |
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
--
+----------------+----------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|  metric_name   |  metric_name   |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+----------------+----------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| cpuKafkaTotals | cpuKafkaTotals | avg(value) |  Pass  |  50.36%   |         0.12678426404794058          |         0.19063538499176502          |
+----------------+----------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
--
+--------------+--------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| metric_name  | metric_name  |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+--------------+--------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| rssFLPTotals | rssFLPTotals | avg(value) |  Pass  |  -19.46%  |             1345875968.0             |             1083939840.0             |
+--------------+--------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
--
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|  metric_name  |  metric_name  |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| rssEBPFTotals | rssEBPFTotals | avg(value) |  Pass  |  -21.83%  |          2234848324.266667           |             1746938368.0             |
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
--
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|  metric_name  |  metric_name  |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| rssLokiTotals | rssLokiTotals | avg(value) |  Pass  |  -56.21%  |            16757993472.0             |             7338251776.0             |
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
--
+----------------+----------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|  metric_name   |  metric_name   |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+----------------+----------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| rssKafkaTotals | rssKafkaTotals | avg(value) |  Pass  |  -28.33%  |          5287129361.066667           |             3789225216.0             |
+----------------+----------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
```