### PR TITLE
Handle more than two days in cron expression

### DIFF
--- a/prow/generate_jobs_in_gsheet/get_periodic_jobs.py
+++ b/prow/generate_jobs_in_gsheet/get_periodic_jobs.py
@@ -64,7 +64,7 @@ def get_cron_in_words(cron_string):
             day_string = f"every {day} days"
         elif "," in day_of_month:
             day = day_of_month.split(',')
-            day_string = f"on day {day[0]} and {day[1]} of the month"
+            day_string = f"on days {day} of the month"
         else: 
             day_string = f"on day {day_of_month} of the month"
         #print("day string" + str(day_string))


### PR DESCRIPTION
Script would only print two days of the cron expression.
Now it can print more than two days of month fields in array format:
`At 0, on days ['1', '8', '15', '22'] of the month`