### PR TITLE
Add ssh to prow image

### DIFF
--- a/prow/Dockerfile
+++ b/prow/Dockerfile
@@ -3,5 +3,5 @@ FROM quay.io/openshifttest/python:3.9
 LABEL vendor="Red Hat Inc." maintainer="OCP QE Team"
 
 RUN curl -sSL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz | tar -xvzf -  &&\
-    mv oc /bin && mv kubectl /bin && apt-get update && apt-get install -y gettext-base uuid-runtime jq && \
+    mv oc /bin && mv kubectl /bin && apt-get update && apt-get install -y gettext-base uuid-runtime jq openssh-client && \
     ln -s /bin/bash /usr/bin/bash && /usr/local/bin/python -m pip install --upgrade pip && pip install virtualenv jq


### PR DESCRIPTION
For the bare metal new scenarios that are being introduced we need ssh in the image.