### PR TITLE
Updating hcp option

### DIFF
--- a/prow/generate_jobs_in_gsheet/get_periodic_jobs.py
+++ b/prow/generate_jobs_in_gsheet/get_periodic_jobs.py
@@ -120,8 +120,8 @@ def get_multiaz(yaml_file):
 def get_cloud_type(yaml_file):
     
     if  "workflow" in yaml_file['steps'].keys(): 
-        if "hypershift" in yaml_file['steps']['workflow']: 
-            return "hypershift"
+        if "hcp" in yaml_file['steps']['workflow']: 
+            return "hcp"
         elif "rosa" in yaml_file['steps']['workflow']:
             return "rosa"
         elif "aro" in yaml_file['steps']['workflow']:


### PR DESCRIPTION
Hypershift is no longer properly being called out in our gooogle sheet of the jobs since the name of the workflow changed from "hypershift" to hcp. This should help this issue
Ex: https://github.com/openshift/release/blob/a45d8237303d117149c08a5c4c56a558fd62dfbf/ci-operator/config/openshift-qe/ocp-qe-perfscale-ci/openshift-qe-ocp-qe-perfscale-ci-main__rosa_hcp-4.14-nightly-x86.yaml#L97