### PR TITLE
Fix metric promql: Bps measured by netobserv

### DIFF
--- a/scripts/queries/netobserv_prometheus_queries.yaml
+++ b/scripts/queries/netobserv_prometheus_queries.yaml
@@ -19,7 +19,7 @@
   metricName: nWorkloadFlowsProcessedPerMinuteTotals
 
 # total bytes processed from workload namespaces by netobserv
-- query: sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace=~"node-density-heavy.*|ingress-perf|cluster-density.*", DstK8S_OwnerType="Deployment"}[1m])*60)
+- query: sum(rate(netobserv_workload_ingress_bytes_total{DstK8S_Namespace=~"node-density-heavy.*|ingress-perf|cluster-density.*",DstK8S_Type!="Service"}[1m])*60)
   metricName: nWorkloadBytesProcessedPerMinuteNetobserv
 
 # total bytes processed from workload namespaces by cadvisor / other means


### PR DESCRIPTION
Changing this promQL for 2 things:
- it was incorrectly looking at traffic going **from** the workloads, but the analog cAdvisor query looks at traffic going **to** the workloads (`container_network_receive_bytes_total{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", namespace=~"node-density-heavy.*|ingress-perf|cluster-density.*"}`). So we need to change `SrcK8S_Namespace` to `DstK8S_Namespace`.
- changing `DstK8S_OwnerType="Deployment"` to `DstK8S_Type!="Service"`. The purpose is the same: eliminate duplicates resulting from the services layer. The new filters are more accurate.