### PR TITLE
use numpy < 2.0.0

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,6 +2,6 @@ argparse>=1.4.0
 requests>=2.25.1
 pyyaml>=5.4.1
 python-jenkins>=1.7.0
-numpy>=1.22.4
+numpy>=1.22.4,<2.0.0
 elasticsearch<7.14.0
 coloredlogs>=15.0.1


### PR DESCRIPTION

numpy 2.0.0 was release on June 16 and breaking our tool with below error. Updating it to use older numpy for time being:

```
$ python nope.py --starttime 1718632785 --endtime 1718635754 --jenkins-job scale-ci/e2e-benchmarking-multibranch-pipeline/kube-burner-ocp --jenkins-build 1564 --uuid 3ac01e3b-6218-4458-9fc3-bb71580721a2 --jira NETOBSERV-1680-wo-loki-kafka-cd-50
Traceback (most recent call last):
  File "/Users/memodi/workspaces/repos/ocp-qe-perfscale-ci/scripts/nope.py", line 18, in <module>
    from elasticsearch import Elasticsearch
  File "/Users/memodi/.local/share/virtualenvs/scripts-WBM3pJit/lib/python3.10/site-packages/elasticsearch/__init__.py", line 36, in <module>
    from .client import Elasticsearch
  File "/Users/memodi/.local/share/virtualenvs/scripts-WBM3pJit/lib/python3.10/site-packages/elasticsearch/client/__init__.py", line 23, in <module>
    from ..transport import Transport, TransportError
  File "/Users/memodi/.local/share/virtualenvs/scripts-WBM3pJit/lib/python3.10/site-packages/elasticsearch/transport.py", line 31, in <module>
    from .serializer import DEFAULT_SERIALIZERS, Deserializer, JSONSerializer
  File "/Users/memodi/.local/share/virtualenvs/scripts-WBM3pJit/lib/python3.10/site-packages/elasticsearch/serializer.py", line 50, in <module>
    np.float_,
  File "/Users/memodi/.local/share/virtualenvs/scripts-WBM3pJit/lib/python3.10/site-packages/numpy/__init__.py", line 397, in __getattr__
    raise AttributeError(
AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.. Did you mean: 'float16'?
```