### PR TITLE
remove kafkaBatchSize

### DIFF
--- a/scripts/netobserv/flows_v1beta2_flowcollector.yaml
+++ b/scripts/netobserv/flows_v1beta2_flowcollector.yaml
@@ -32,7 +32,6 @@ objects:
               cpu: 100m
             limits:
               memory: ${EBPFMemoryLimit}
-          kafkaBatchSize: 10485760
       processor:
         imagePullPolicy: IfNotPresent
         logLevel: trace


### PR DESCRIPTION
this trickled in when I moved to use flowcollector template, having it in causing very high ebpf memory usage.

Sorry, this cause multiple bugs, hopefully it's the last one. 