### PR TITLE
NETOBSERV-1715 add total cluster metrics and % netobserv metrics

### DIFF
--- a/scripts/netobserv/flows_v1beta2_flowcollector.yaml
+++ b/scripts/netobserv/flows_v1beta2_flowcollector.yaml
@@ -13,58 +13,17 @@ objects:
       agent:
         type: eBPF
         ebpf:
-          imagePullPolicy: IfNotPresent
           sampling: ${{EBPFSamplingRate}}
           cacheMaxFlows: ${{EBPFCacheMaxFlows}}
-          interfaces: [ ]
-          excludeInterfaces: ["lo"]
-          logLevel: info
           privileged: "${{EBPFPrivileged}}"
-          metrics:
-            enable: true
-            server:
-              port: 9400
-              tls:
-                type: Auto
           resources:
-            requests:
-              memory: 50Mi
-              cpu: 100m
             limits:
               memory: ${EBPFMemoryLimit}
       processor:
-        imagePullPolicy: IfNotPresent
-        logLevel: info
-        multiClusterDeployment: false
-        addZone: false
-        metrics:
-          includeList:
-            - node_ingress_bytes_total
-            - workload_ingress_bytes_total
-            - namespace_flows_total
-          server:
-            port: 9401
-            tls:
-              type: Auto
-          disableAlerts: []
         resources:
-          requests:
-            memory: 100Mi
-            cpu: 100m
           limits:
             memory: ${FLPMemoryLimit}
         kafkaConsumerReplicas: ${{KafkaConsumerReplicas}}
-        kafkaConsumerAutoscaler: null
-        kafkaConsumerQueueCapacity: 1000
-        kafkaConsumerBatchSize: 10485760
-        logTypes: Flows
-        advanced:
-          port: 2055
-          profilePort: 6060
-          dropUnusedFields: true
-          conversationTerminatingTimeout: 5s
-          conversationHeartbeatInterval: 5s
-          conversationEndTimeout: 20s
       kafka:
         address: kafka-cluster-kafka-bootstrap.netobserv
         topic: network-flows
@@ -73,44 +32,6 @@ objects:
       loki:
         mode: LokiStack
         enable: "${{LokiEnable}}"
-        lokiStack:
-          name: lokistack
-        writeBatchWait: 1s
-        writeBatchSize: 10485760
-        advanced:
-          writeMinBackoff: 1s
-          writeMaxBackoff: 5s
-          writeMaxRetries: 2
-      consolePlugin:
-        enable: true
-        imagePullPolicy: IfNotPresent
-        logLevel: info
-        portNaming:
-          enable: true
-          portNames:
-            "3100": loki
-        quickFilters:
-        - name: Applications
-          filter:
-            src_namespace!: 'openshift-,netobserv'
-            dst_namespace!: 'openshift-,netobserv'
-          default: true
-        - name: Infrastructure
-          filter:
-            src_namespace: 'openshift-,netobserv'
-            dst_namespace: 'openshift-,netobserv'
-        - name: Pods network
-          filter:
-            src_kind: 'Pod'
-            dst_kind: 'Pod'
-          default: true
-        - name: Services network
-          filter:
-            dst_kind: 'Service'
-        advanced:
-          port: 9001
-          register: true
-      exporters: []
 parameters:
   - name: DeploymentModel
     value: "Kafka"

--- a/scripts/queries/netobserv_prometheus_queries.yaml
+++ b/scripts/queries/netobserv_prometheus_queries.yaml
@@ -171,13 +171,29 @@
   metricName: workingsetKafkaTotals
 
 ###########################
-# Total NetObserv metrics #
+# Total metrics #
 ###########################
 
 # Total NetObserv CPU Usage, assuming Loki and Kafka also runs in netobserv NS
-- query: (sum(pod:container_cpu_usage:sum{namespace=~"netobserv.*|openshift-netobserv-operator"}) or on() vector(0))
+- query: (sum(pod:container_cpu_usage:sum{namespace=~".*netobserv.*"}) or on() vector(0))
   metricName: TotalNetObservCPUUsage
 
 # Total NetObserv RSS Usage, assuming Loki and Kafka also runs in netobserv NS
-- query:  (sum(container_memory_rss{namespace=~"netobserv.*|openshift-netobserv-operator", container=""}) or on() vector(0))
+- query:  (sum(container_memory_rss{namespace=~".*netobserv.*", container=""}) or on() vector(0))
   metricName: TotalNetObservRSSUsage
+
+# Total Cluster CPU Usage
+- query:  sum(label_replace(cluster:cpu_usage_cores:sum{prometheus="openshift-monitoring/k8s"}, "resource", "cluster_cpu_usage", "prometheus", ".*")) by (resource)
+  metricName: TotalClusterCPUUsage
+
+# Total Cluster Memory Usage
+- query:  sum(label_replace(cluster:memory_usage_bytes:sum{prometheus="openshift-monitoring/k8s"}, "resource", "cluster_memory_usage", "prometheus", ".*")) by (resource)
+  metricName: TotalClusterRSSUsage
+
+# NetObserv % CPU usage as a factor total cluster CPU usage
+- query: sum(label_replace((((sum(namespace:container_cpu_usage:sum{namespace=~".*netobserv.*"})) / on() group_right() cluster:cpu_usage_cores:sum)*100), "resource", "cpu_usage%", "prometheus", ".*")) by (resource)
+  metricName: NetObservClusterCPUPercentUtil
+
+# NetObserv % memory usage as a factor total cluster memory usage
+- query: sum(label_replace((sum(container_memory_usage_bytes{namespace=~".*netobserv.*",  container=""}) / on() group_right() cluster:memory_usage_bytes:sum)*100, "resource", "memory_usage%", "prometheus", ".*")) by (resource)
+  metricName: NetObservClusterMemPercentUtil

--- a/scripts/queries/netobserv_touchstone_statistics_config.json
+++ b/scripts/queries/netobserv_touchstone_statistics_config.json
@@ -732,6 +732,58 @@
                         "avg"
                     ]
                 }
+            },
+            {
+                "filter": {
+                    "metric_name.keyword": "TotalClusterCPUUsage"
+                },
+                "buckets": [
+                    "metadata.resource.keyword"
+                ],
+                "aggregations": {
+                    "value": [
+                        "avg"
+                    ]
+                }
+            },
+            {
+                "filter": {
+                    "metric_name.keyword": "TotalClusterRSSUsage"
+                },
+                "buckets": [
+                    "metadata.resource.keyword"
+                ],
+                "aggregations": {
+                    "value": [
+                        "avg"
+                    ]
+                }
+            },
+            {
+                "filter": {
+                    "metric_name.keyword": "NetObservClusterCPUPercentUtil"
+                },
+                "buckets": [
+                    "metadata.resource.keyword"
+                ],
+                "aggregations": {
+                    "value": [
+                        "avg"
+                    ]
+                }
+            },
+            {
+                "filter": {
+                    "metric_name.keyword": "NetObservClusterMemPercentUtil"
+                },
+                "buckets": [
+                    "metadata.resource.keyword"
+                ],
+                "aggregations": {
+                    "value": [
+                        "avg"
+                    ]
+                }
             }
         ]
     }

--- a/scripts/queries/netobserv_touchstone_tolerancy_config.json
+++ b/scripts/queries/netobserv_touchstone_tolerancy_config.json
@@ -481,6 +481,58 @@
                         "avg"
                     ]
                 }
+            },
+            {
+                "filter": {
+                    "metric_name.keyword": "TotalClusterCPUUsage"
+                },
+                "buckets": [
+                    "metadata.resource.keyword"
+                ],
+                "aggregations": {
+                    "value": [
+                        "avg"
+                    ]
+                }
+            },
+            {
+                "filter": {
+                    "metric_name.keyword": "TotalClusterRSSUsage"
+                },
+                "buckets": [
+                    "metadata.resource.keyword"
+                ],
+                "aggregations": {
+                    "value": [
+                        "avg"
+                    ]
+                }
+            },
+            {
+                "filter": {
+                    "metric_name.keyword": "NetObservClusterCPUPercentUtil"
+                },
+                "buckets": [
+                    "metadata.resource.keyword"
+                ],
+                "aggregations": {
+                    "value": [
+                        "avg"
+                    ]
+                }
+            },
+            {
+                "filter": {
+                    "metric_name.keyword": "NetObservClusterMemPercentUtil"
+                },
+                "buckets": [
+                    "metadata.resource.keyword"
+                ],
+                "aggregations": {
+                    "value": [
+                        "avg"
+                    ]
+                }
             }
         ]
     }

--- a/scripts/queries/netobserv_touchstone_tolerancy_rules.yaml
+++ b/scripts/queries/netobserv_touchstone_tolerancy_rules.yaml
@@ -58,9 +58,23 @@
 - json_path: ["metric_name", "rssKafkaTotals", "metric_name", "*", "avg(value)"]
   tolerancy: 60
   max_failures: 0
+# total usages
 - json_path: ["metric_name", "TotalNetObservCPUUsage", "metric_name", "*", "avg(value)"]
   tolerancy: 10
   max_failures: 0
 - json_path: ["metric_name", "TotalNetObservRSSUsage", "metric_name", "*", "avg(value)"]
+  tolerancy: 10
+  max_failures: 0
+# total usages
+- json_path: ["metric_name", "TotalClusterCPUUsage", "metric_name", "*", "avg(value)"]
+  tolerancy: 60
+  max_failures: 0
+- json_path: ["metric_name", "TotalClusterRSSUsage", "metric_name", "*", "avg(value)"]
+  tolerancy: 60
+  max_failures: 0
+- json_path: ["metric_name", "NetObservClusterCPUPercentUtil", "metric_name", "*", "avg(value)"]
+  tolerancy: 10
+  max_failures: 0
+- json_path: ["metric_name", "NetObservClusterMemPercentUtil", "metric_name", "*", "avg(value)"]
   tolerancy: 10
   max_failures: 0


### PR DESCRIPTION
- adding total cluster metrics and netobserv % metrics as a factor of cluster usage
- also cleaning up flowcollector to use default as much as possible

Success run: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/memodi-e2e-benchmarking-multibranch-pipeline/job/prom-metrics/2/console and it's [spreadsheet](https://docs.google.com/spreadsheets/d/1xQ6427XeavlEkSMa1cFeAnZyZQ9hUKecgS8JE42RxMs/edit?gid=233562004#gid=233562004) (scroll to bottom for new metrics)