### PR TITLE
Spreadsheet links in build info and cross-reference in spreadsheets

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -154,3 +154,6 @@ touchstone_compare -url $ES_URL -u d9be1710-abdb-420d-86da-883da583aa03 363eb0de
 where workloads UUIDs are:
 - `d9be1710-abdb-420d-86da-883da583aa03` for 1.2 node-density-heavy
 - `363eb0de-9213-4d9c-a347-849007003742` for 1.3 node-density-heavy
+
+## Performance comparison sheets update
+[noo_perfsheets_update.py](scripts/sheets/noo_perfsheets_update.py) is a tool to update the performance comparison sheets that are generated during the network observability performance testings runs which makes use of upstream tool [csv_gen.py](https://github.com/cloud-bulldozer/e2e-benchmarking/blob/master/utils/csv_gen.py). It  replaces the UUIDs with identifiable information and removes redundant rows from the initial generated sheet. To update the correct sheet it relies on [log line](https://github.com/cloud-bulldozer/e2e-benchmarking/blob/master/utils/csv_gen.py#L47) to fetch the sheet name in the Jenkins pipeline.

--- a/scripts/netobserv/flows_v1beta2_flowcollector.yaml
+++ b/scripts/netobserv/flows_v1beta2_flowcollector.yaml
@@ -34,6 +34,7 @@ objects:
         enable: "${{LokiEnable}}"
         lokiStack:
           name: lokistack
+        writeBatchSize: 10485760 # remove this when NETOBSERV-1766 is fixed
 parameters:
   - name: DeploymentModel
     value: "Kafka"

--- a/scripts/queries/netobserv_touchstone_statistics_config.json
+++ b/scripts/queries/netobserv_touchstone_statistics_config.json
@@ -3,6 +3,7 @@
         "metadata": {
             "prod-netobserv-operator-metadata": {
                 "fields": [
+                    "uuid_replaced_info",
                     "agent",
                     "arch",
                     "aws_s3_bucket_name",
@@ -27,6 +28,7 @@
             },
             "prod-netobserv-jenkins-metadata": {
                 "fields": [
+                    "buildUrl",
                     "jenkins_build_num",
                     "jenkins_job_name",
                     "variable",


### PR DESCRIPTION
This has following changes and fixes:
- link Sheets to build description
- New ES fields for cross-referencing jenkins job and spreadsheets: buildUrl, uuid_replaced_info.
- use loki.batchWriteSize to 10 MB until [NETOBSERV-1766](https://issues.redhat.com//browse/NETOBSERV-1766) is fixed
- other minor fixes

[Success run](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/memodi-e2e-benchmarking-multibranch-pipeline/job/ss-links/11/) which links the spreadsheets as well in build info.