### PR TITLE
Taking out oc

### DIFF
--- a/prow/Dockerfile
+++ b/prow/Dockerfile
@@ -2,8 +2,5 @@ FROM quay.io/openshifttest/python:3.9
 
 LABEL vendor="Red Hat Inc." maintainer="OCP QE Team"
 
-RUN curl -sSL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux-amd64-rhel8.tar.gz | tar -xvzf -  &&\
-    mv oc /bin && mv kubectl /bin && apt-get update && apt-get install -y gettext-base uuid-runtime jq openssh-client sshpass && \
+RUN apt-get update && apt-get install -y gettext-base uuid-runtime jq openssh-client sshpass && \
     ln -s /bin/bash /usr/bin/bash && /usr/local/bin/python -m pip install --upgrade pip && pip install virtualenv jq
-
-RUN oc version


### PR DESCRIPTION
Want to take out oc so that the tests will install specific versions of the cli in each test 

Using the Dockerfile_test (which I copied to update the Dockerfile here) 

I had successful run here: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/54209/rehearse-54209-pull-ci-openshift-qe-ocp-qe-perfscale-ci-main-gcp-4.15-nightly-arm-test/1816839020982833152
And got proper cli version 

```
Python 3.9.9
Client Version: 4.15.0-202407120536.p0.g1e41aa3.assembly.stream.el8-1e41aa3
Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
Kubernetes Version: v1.28.11+add48d0
```