### PR TITLE
Adding kubectl into base image 

### DIFF
--- a/prow/Dockerfile
+++ b/prow/Dockerfile
@@ -2,6 +2,5 @@ FROM quay.io/openshifttest/python:3.9
 
 LABEL vendor="Red Hat Inc." maintainer="OCP QE Team"
 
-
 RUN apt-get update && apt-get install -y gettext-base uuid-runtime jq openssh-client sshpass && \
     ln -s /bin/bash /usr/bin/bash && /usr/local/bin/python -m pip install --upgrade pip && pip install virtualenv jq

--- a/prow/Dockerfile
+++ b/prow/Dockerfile
@@ -2,5 +2,8 @@ FROM quay.io/openshifttest/python:3.9
 
 LABEL vendor="Red Hat Inc." maintainer="OCP QE Team"
 
+RUN curl -sSL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux-amd64-rhel8.tar.gz | tar -xvzf -  &&\
+    mv kubectl /bin 
+
 RUN apt-get update && apt-get install -y gettext-base uuid-runtime jq openssh-client sshpass && \
     ln -s /bin/bash /usr/bin/bash && /usr/local/bin/python -m pip install --upgrade pip && pip install virtualenv jq


### PR DESCRIPTION
Need kubectl cli since its not added with cli: latest we're now using

CC: @jtaleric 

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/55839/rehearse-55839-periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-metal-4.16-latest-x86-weekly-6nodes/1826308991307747328