### PR TITLE
use 4.16 opm-rhel8 binary

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -634,9 +634,9 @@ pipeline {
                             RELEASE=$(oc get pods -l app=netobserv-operator -o jsonpath='{.items[*].spec.containers[1].env[0].value}' -A | cut -d 'v' -f 3)
 
                             # source from 4.12 because jenkins agent are on RHEL 8
-                            curl -sL "https://mirror2.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-4.12/opm-linux.tar.gz" -o opm-linux.tar.gz
+                            curl -sL "https://mirror2.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-4.16/opm-linux.tar.gz" -o opm-linux.tar.gz
                             tar xf opm-linux.tar.gz
-                            BUNDLE_IMAGE=$(./opm alpha list bundles $CATALOG_IMAGE netobserv-operator | grep $RELEASE | awk '{print $5}')
+                            BUNDLE_IMAGE=$(./opm-rhel8 alpha list bundles $CATALOG_IMAGE netobserv-operator | grep $RELEASE | awk '{print $5}')
                             oc image info $BUNDLE_IMAGE -o json --filter-by-os linux/amd64 | jq '.config.config.Labels.url' | awk -F '/' '{print $NF}' | tr '\"' ' '
                         ''').trim()
                     if (NOO_BUNDLE_VERSION != '') {
@@ -859,8 +859,8 @@ pipeline {
                         env.NOO_BUNDLE_VERSION=NOO_BUNDLE_VERSION
                         // construct arguments for NOPE tool and execute
                         NOPE_ARGS = '--starttime $STARTDATEUNIXTIMESTAMP --endtime $ENDDATEUNIXTIMESTAMP --jenkins-job $JENKINS_JOB --jenkins-build $JENKINS_BUILD --uuid $UUID'
-                        if (env.NOO_BUNDLE_VERSION != ''){
-                            NOPE_ARGS += " --noo-bundle-version $NOO_BUNDLE_VERSION"
+                        if (NOO_BUNDLE_VERSION != ''){
+                            NOPE_ARGS += " --noo-bundle-version ${NOO_BUNDLE_VERSION}"
                         }
                         if (params.NOPE_DUMP_ONLY == true) {
                             NOPE_ARGS += " --dump-only"


### PR DESCRIPTION
fix for error: `time=“2024-08-13T07:05:41Z” level=fatal msg=“invalid character ‘>’ in string escape code”`

tested this change here: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/memodi-e2e-benchmarking-multibranch-pipeline/job/add-prom2/11/console

also fixing where nope.py failed with:
```
08-26 07:48:05.684  + python /home/jenkins/ws/workspace/ch-pipeline_netobserv-perf-tests/ocp-qe-perfscale-ci/scripts/nope.py --starttime 1724671933 --endtime 1724672631 --jenkins-job scale-ci/e2e-benchmarking-multibranch-pipeline/kube-burner-ocp --jenkins-build 1819 --uuid 1e8e691e-2da0-4067-8a00-c92408fa276b --noo-bundle-version
08-26 07:48:06.036  usage: nope.py [-h] [--debug] [--yaml-file YAML_FILE] [--starttime STARTTIME]
08-26 07:48:06.036                 [--endtime ENDTIME] [--step STEP] [--jenkins-job JENKINS_JOB]
08-26 07:48:06.036                 [--jenkins-build JENKINS_BUILD] [--uuid UUID] [--dump-only]
08-26 07:48:06.036                 [--jira JIRA] [--noo-bundle-version NOO_BUNDLE_VERSION]
08-26 07:48:06.036                 {upload,baseline} ...
```
if NOO_BUNDLE_VERSION is not set it should not add --noo-bundle-version args 