### PR TITLE
NETOBSERV-1878 use loki 6.0 channel for OCP >= 4.17

### DIFF
--- a/scripts/loki/loki-released-subscription.yaml
+++ b/scripts/loki/loki-released-subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: loki-operator
   namespace: openshift-operators-redhat
 spec:
-  channel: stable
+  channel: stable-6.0
   name: loki-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/scripts/loki/loki-unreleased-subscription.yaml
+++ b/scripts/loki/loki-unreleased-subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: loki-operator
   namespace: openshift-operators-redhat
 spec:
-  channel: stable
+  channel: stable-6.0
   name: loki-operator
   source: netobserv-downstream-testing
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
[NETOBSERV-1878](https://issues.redhat.com//browse/NETOBSERV-1878) use loki 6.0 channel for OCP >= 4.17