### PR TITLE
NETOBSERV-1715 clean up tolerancy and fixes for NetObservCluster CPU/Mem PercentUtil metrics

### DIFF
--- a/scripts/queries/netobserv_touchstone_tolerancy_config.json
+++ b/scripts/queries/netobserv_touchstone_tolerancy_config.json
@@ -37,73 +37,6 @@
                 ]
             }
         },
-        "ripsaw-kube-burner": [
-            {
-                "filter": {
-                    "metricName.keyword": "namespaceCount"
-                },
-                "buckets": [
-                    "metricName.keyword"
-                ],
-                "aggregations": {
-                    "value": [
-                        "max"
-                    ]
-                }
-            },
-            {
-                "filter": {
-                    "metricName.keyword": "podStatusCount"
-                },
-                "buckets": [
-                    "metricName.keyword"
-                ],
-                "aggregations": {
-                    "value": [
-                        "max"
-                    ]
-                }
-            },
-            {
-                "filter": {
-                    "metricName.keyword": "deploymentCount"
-                },
-                "buckets": [
-                    "metricName.keyword"
-                ],
-                "aggregations": {
-                    "value": [
-                        "max"
-                    ]
-                }
-            },
-            {
-                "filter": {
-                    "metricName.keyword": "replicaSetCount"
-                },
-                "buckets": [
-                    "metricName.keyword"
-                ],
-                "aggregations": {
-                    "value": [
-                        "max"
-                    ]
-                }
-            },
-            {
-                "filter": {
-                    "metricName.keyword": "serviceCount"
-                },
-                "buckets": [
-                    "metricName.keyword"
-                ],
-                "aggregations": {
-                    "value": [
-                        "max"
-                    ]
-                }
-            }
-        ],
         "prod-netobserv-datapoints": [
             {
                 "filter": {
@@ -244,13 +177,6 @@
                 ],
                 "aggregations": {
                     "value": [
-                        {
-                            "percentiles": {
-                                "percents": [
-                                    90
-                                ]
-                            }
-                        },
                         "avg"
                     ]
                 }
@@ -264,13 +190,6 @@
                 ],
                 "aggregations": {
                     "value": [
-                        {
-                            "percentiles": {
-                                "percents": [
-                                    90
-                                ]
-                            }
-                        },
                         "avg"
                     ]
                 }
@@ -284,13 +203,6 @@
                 ],
                 "aggregations": {
                     "value": [
-                        {
-                            "percentiles": {
-                                "percents": [
-                                    90
-                                ]
-                            }
-                        },
                         "avg"
                     ]
                 }
@@ -304,13 +216,6 @@
                 ],
                 "aggregations": {
                     "value": [
-                        {
-                            "percentiles": {
-                                "percents": [
-                                    90
-                                ]
-                            }
-                        },
                         "avg"
                     ]
                 }
@@ -324,13 +229,6 @@
                 ],
                 "aggregations": {
                     "value": [
-                        {
-                            "percentiles": {
-                                "percents": [
-                                    90
-                                ]
-                            }
-                        },
                         "avg"
                     ]
                 }
@@ -344,13 +242,6 @@
                 ],
                 "aggregations": {
                     "value": [
-                        {
-                            "percentiles": {
-                                "percents": [
-                                    90
-                                ]
-                            }
-                        },
                         "avg"
                     ]
                 }
@@ -364,13 +255,6 @@
                 ],
                 "aggregations": {
                     "value": [
-                        {
-                            "percentiles": {
-                                "percents": [
-                                    90
-                                ]
-                            }
-                        },
                         "avg"
                     ]
                 }
@@ -384,13 +268,6 @@
                 ],
                 "aggregations": {
                     "value": [
-                        {
-                            "percentiles": {
-                                "percents": [
-                                    90
-                                ]
-                            }
-                        },
                         "avg"
                     ]
                 }
@@ -404,13 +281,6 @@
                 ],
                 "aggregations": {
                     "value": [
-                        {
-                            "percentiles": {
-                                "percents": [
-                                    90
-                                ]
-                            }
-                        },
                         "avg"
                     ]
                 }
@@ -424,13 +294,6 @@
                 ],
                 "aggregations": {
                     "value": [
-                        {
-                            "percentiles": {
-                                "percents": [
-                                    90
-                                ]
-                            }
-                        },
                         "avg"
                     ]
                 }
@@ -466,7 +329,7 @@
                     "metric_name.keyword": "TotalClusterCPUUsage"
                 },
                 "buckets": [
-                    "metadata.resource.keyword"
+                    "metric_name.keyword"
                 ],
                 "aggregations": {
                     "value": [
@@ -479,7 +342,7 @@
                     "metric_name.keyword": "TotalClusterRSSUsage"
                 },
                 "buckets": [
-                    "metadata.resource.keyword"
+                    "metric_name.keyword"
                 ],
                 "aggregations": {
                     "value": [
@@ -518,7 +381,7 @@
                     "metric_name.keyword": "NetObservClusterCPUPercentUtil"
                 },
                 "buckets": [
-                    "metadata.resource.keyword"
+                    "metric_name.keyword"
                 ],
                 "aggregations": {
                     "value": [
@@ -531,7 +394,7 @@
                     "metric_name.keyword": "NetObservClusterMemPercentUtil"
                 },
                 "buckets": [
-                    "metadata.resource.keyword"
+                    "metric_name.keyword"
                 ],
                 "aggregations": {
                     "value": [


### PR DESCRIPTION
[NETOBSERV-1715](https://issues.redhat.com//browse/NETOBSERV-1715) clean up tolerancy and fixes for NetObservCluster CPU/Mem PercentUtil metrics, ran a test with new config:

```
$ touchstone_compare.sh be417bf8-4366-4fef-9984-f0cbc27aa1c8 cbbead45-3e8b-48fd-a1fd-02ce82f83d80
File ‘netobserv_touchstone_tolerancy_config.json’ already there; not retrieving.

File ‘netobserv_touchstone_tolerancy_rules.yaml’ already there; not retrieving.

deviation is -28.92470763737363
+-----------------------+-----------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|      metric_name      |      metric_name      |   metric   | result | deviation | be417bf8-4366-4fef-9984-f0cbc27aa1c8 | cbbead45-3e8b-48fd-a1fd-02ce82f83d80 |
+-----------------------+-----------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| nFlowsProcessedTotals | nFlowsProcessedTotals | max(value) |  Fail  |  -28.92%  |              6968914.0               |              4953176.0               |
+-----------------------+-----------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
deviation is -30.521492651337468
+-------------------------------+-------------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|          metric_name          |          metric_name          |   metric   | result | deviation | be417bf8-4366-4fef-9984-f0cbc27aa1c8 | cbbead45-3e8b-48fd-a1fd-02ce82f83d80 |
+-------------------------------+-------------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| nWorkloadFlowsProcessedTotals | nWorkloadFlowsProcessedTotals | max(value) |  Fail  |  -30.52%  |               560238.0               |               389245.0               |
+-------------------------------+-------------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
deviation is 0
+--------------------+--------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|    metric_name     |    metric_name     |   metric   | result | deviation | be417bf8-4366-4fef-9984-f0cbc27aa1c8 | cbbead45-3e8b-48fd-a1fd-02ce82f83d80 |
+--------------------+--------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| nFlowsErroredRatio | nFlowsErroredRatio | avg(value) |  Pass  |   0.00%   |                 0.0                  |                 0.0                  |
+--------------------+--------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
deviation is -28.922080110364817
+--------------------+--------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|    metric_name     |    metric_name     |   metric   | result | deviation | be417bf8-4366-4fef-9984-f0cbc27aa1c8 | cbbead45-3e8b-48fd-a1fd-02ce82f83d80 |
+--------------------+--------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| lokiRecordsWritten | lokiRecordsWritten | max(value) |  Fail  |  -28.92%  |              6967438.0               |              4952310.0               |
+--------------------+--------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
deviation is 0
+-----------------------+-----------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|      metric_name      |      metric_name      |   metric   | result | deviation | be417bf8-4366-4fef-9984-f0cbc27aa1c8 | cbbead45-3e8b-48fd-a1fd-02ce82f83d80 |
+-----------------------+-----------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| ebpfFlowsDroppedRatio | ebpfFlowsDroppedRatio | avg(value) |  Pass  |   0.00%   |                 0.0                  |                 0.0                  |
+-----------------------+-----------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
deviation is 0
+-------------------------+-------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|       metric_name       |       metric_name       |   metric   | result | deviation | be417bf8-4366-4fef-9984-f0cbc27aa1c8 | cbbead45-3e8b-48fd-a1fd-02ce82f83d80 |
+-------------------------+-------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| lokiRecordsDroppedRatio | lokiRecordsDroppedRatio | avg(value) |  Pass  |   0.00%   |                 0.0                  |                 0.0                  |
+-------------------------+-------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
deviation is 4.108917764458951
+--------------+--------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| metric_name  | metric_name  |   metric   | result | deviation | be417bf8-4366-4fef-9984-f0cbc27aa1c8 | cbbead45-3e8b-48fd-a1fd-02ce82f83d80 |
+--------------+--------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| cpuFLPTotals | cpuFLPTotals | avg(value) |  Pass  |   4.11%   |          0.8212308608568631          |          0.8549745615858299          |
+--------------+--------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
deviation is -8.646783560887926
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|  metric_name  |  metric_name  |   metric   | result | deviation | be417bf8-4366-4fef-9984-f0cbc27aa1c8 | cbbead45-3e8b-48fd-a1fd-02ce82f83d80 |
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| cpuEBPFTotals | cpuEBPFTotals | avg(value) |  Pass  |  -8.65%   |          0.9471667317243723          |          0.8652672744714297          |
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
deviation is -9.236103887798095
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|  metric_name  |  metric_name  |   metric   | result | deviation | be417bf8-4366-4fef-9984-f0cbc27aa1c8 | cbbead45-3e8b-48fd-a1fd-02ce82f83d80 |
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| cpuLokiTotals | cpuLokiTotals | avg(value) |  Pass  |  -9.24%   |          0.2569400943242587          |         0.23320884028306374          |
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
deviation is 44.58708254629809
+----------------+----------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|  metric_name   |  metric_name   |   metric   | result | deviation | be417bf8-4366-4fef-9984-f0cbc27aa1c8 | cbbead45-3e8b-48fd-a1fd-02ce82f83d80 |
+----------------+----------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| cpuKafkaTotals | cpuKafkaTotals | avg(value) |  Pass  |  44.59%   |          0.125372014939785           |         0.18127173873094413          |
+----------------+----------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
deviation is 28.180451773559867
+---------------------+---------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|     metric_name     |     metric_name     |   metric   | result | deviation | be417bf8-4366-4fef-9984-f0cbc27aa1c8 | cbbead45-3e8b-48fd-a1fd-02ce82f83d80 |
+---------------------+---------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| cpuPrometheusTotals | cpuPrometheusTotals | avg(value) |  Pass  |  28.18%   |         0.007112380294129253         |         0.009116681192868523         |
+---------------------+---------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
deviation is -10.12360527409993
+--------------+--------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| metric_name  | metric_name  |   metric   | result | deviation | be417bf8-4366-4fef-9984-f0cbc27aa1c8 | cbbead45-3e8b-48fd-a1fd-02ce82f83d80 |
+--------------+--------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| rssFLPTotals | rssFLPTotals | avg(value) |  Pass  |  -10.12%  |          458447950.7692308           |          412036489.84615386          |
+--------------+--------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
deviation is -6.054762491096241
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|  metric_name  |  metric_name  |   metric   | result | deviation | be417bf8-4366-4fef-9984-f0cbc27aa1c8 | cbbead45-3e8b-48fd-a1fd-02ce82f83d80 |
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| rssEBPFTotals | rssEBPFTotals | avg(value) |  Pass  |  -6.05%   |          1903815758.7692308          |          1788544236.3076923          |
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
deviation is -22.411480204540894
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|  metric_name  |  metric_name  |   metric   | result | deviation | be417bf8-4366-4fef-9984-f0cbc27aa1c8 | cbbead45-3e8b-48fd-a1fd-02ce82f83d80 |
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| rssLokiTotals | rssLokiTotals | avg(value) |  Pass  |  -22.41%  |             7493603328.0             |          5814175901.538462           |
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
deviation is -4.197265916598724
+----------------+----------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|  metric_name   |  metric_name   |   metric   | result | deviation | be417bf8-4366-4fef-9984-f0cbc27aa1c8 | cbbead45-3e8b-48fd-a1fd-02ce82f83d80 |
+----------------+----------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| rssKafkaTotals | rssKafkaTotals | avg(value) |  Pass  |  -4.20%   |          3889433363.6923075          |          3726183502.769231           |
+----------------+----------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
deviation is 51.275494621944915
+---------------------+---------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|     metric_name     |     metric_name     |   metric   | result | deviation | be417bf8-4366-4fef-9984-f0cbc27aa1c8 | cbbead45-3e8b-48fd-a1fd-02ce82f83d80 |
+---------------------+---------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| rssPrometheusTotals | rssPrometheusTotals | avg(value) |  Pass  |  51.28%   |             105890484.0              |          160186353.42857143          |
+---------------------+---------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
deviation is -0.7819906689031768
+------------------------+------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|      metric_name       |      metric_name       |   metric   | result | deviation | be417bf8-4366-4fef-9984-f0cbc27aa1c8 | cbbead45-3e8b-48fd-a1fd-02ce82f83d80 |
+------------------------+------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| TotalNetObservCPUUsage | TotalNetObservCPUUsage | avg(value) |  Pass  |  -0.78%   |          2.165961659871615           |          2.1490240417993984          |
+------------------------+------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
deviation is -14.473757524383899
+------------------------+------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|      metric_name       |      metric_name       |   metric   | result | deviation | be417bf8-4366-4fef-9984-f0cbc27aa1c8 | cbbead45-3e8b-48fd-a1fd-02ce82f83d80 |
+------------------------+------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| TotalNetObservRSSUsage | TotalNetObservRSSUsage | avg(value) |  Pass  |  -14.47%  |          13888178648.615385          |          11878037346.461538          |
+------------------------+------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
deviation is -5.214786312290343
+----------------------+----------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|     metric_name      |     metric_name      |   metric   | result | deviation | be417bf8-4366-4fef-9984-f0cbc27aa1c8 | cbbead45-3e8b-48fd-a1fd-02ce82f83d80 |
+----------------------+----------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| TotalClusterCPUUsage | TotalClusterCPUUsage | avg(value) |  Pass  |  -5.21%   |          46.48698799426739           |          44.06279090734628           |
+----------------------+----------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
deviation is -4.338332376153318
+----------------------+----------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|     metric_name      |     metric_name      |   metric   | result | deviation | be417bf8-4366-4fef-9984-f0cbc27aa1c8 | cbbead45-3e8b-48fd-a1fd-02ce82f83d80 |
+----------------------+----------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| TotalClusterRSSUsage | TotalClusterRSSUsage | avg(value) |  Pass  |  -4.34%   |          153299818653.53845          |          146649162988.30768          |
+----------------------+----------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
deviation is -13.090743767830944
+----------------------+----------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|     metric_name      |     metric_name      |   metric   | result | deviation | be417bf8-4366-4fef-9984-f0cbc27aa1c8 | cbbead45-3e8b-48fd-a1fd-02ce82f83d80 |
+----------------------+----------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| TotalNetworkBytesOut | TotalNetworkBytesOut | avg(value) |  Pass  |  -13.09%  |          74850683.84615384           |          65052172.615384616          |
+----------------------+----------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
deviation is -14.866939530195197
+---------------------+---------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|     metric_name     |     metric_name     |   metric   | result | deviation | be417bf8-4366-4fef-9984-f0cbc27aa1c8 | cbbead45-3e8b-48fd-a1fd-02ce82f83d80 |
+---------------------+---------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| TotalNetworkBytesIn | TotalNetworkBytesIn | avg(value) |  Fail  |  -14.87%  |          82571341.84615384           |          70295510.38461539           |
+---------------------+---------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
deviation is 5.833463912825209
+--------------------------------+--------------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|          metric_name           |          metric_name           |   metric   | result | deviation | be417bf8-4366-4fef-9984-f0cbc27aa1c8 | cbbead45-3e8b-48fd-a1fd-02ce82f83d80 |
+--------------------------------+--------------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| NetObservClusterCPUPercentUtil | NetObservClusterCPUPercentUtil | avg(value) |  Pass  |   5.83%   |           5.8970276759221            |          6.241028657326331           |
+--------------------------------+--------------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
deviation is -11.897144611701705
+--------------------------------+--------------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|          metric_name           |          metric_name           |   metric   | result | deviation | be417bf8-4366-4fef-9984-f0cbc27aa1c8 | cbbead45-3e8b-48fd-a1fd-02ce82f83d80 |
+--------------------------------+--------------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| NetObservClusterMemPercentUtil | NetObservClusterMemPercentUtil | avg(value) |  Pass  |  -11.90%  |          15.259758509122408          |          13.444282971895658          |
+--------------------------------+--------------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
```