### PR TITLE
Adding more reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,15 +1,24 @@
 approvers:
-- mffiedler
-- qiliRedHat
-- paigerube14
+- afcollins
 - jtaleric
+- josecastillolema
+- mffiedler
+- paigerube14
+- qiliredhat
+- rsevilla87
 - svetsa-rh
 reviewers:
-- qiliRedHat
 - mffiedler
 - paigerube14
 - rpattath
 - skordas
-- memodi
 - jtaleric
 - svetsa-rh
+- shahsahil264
+- liqcui
+- krishvoor
+- afcollins
+- rsevilla87
+- vishnuchalla
+- sachinninganure
+- chaitanyaenr


### PR DESCRIPTION
Looks like the owners in config and jobs come from this file, adding perfscale dev to align with the OWNERS in the step-registry

https://github.com/josecastillolema/release/blob/05ae225ad9869df0900201a76997d60172867fb8/ci-operator/jobs/openshift-qe/ocp-qe-perfscale-ci/OWNERS#L1-L2