### PR TITLE
While loop to wait for loki-operator and bug fix in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -888,7 +888,6 @@ pipeline {
                                     baselineReturnCode = sh(returnStatus: true, script: """
                                             source $WORKSPACE/ocp-qe-perfscale-ci/scripts/run_py_scripts.sh
                                             run_comparison
-                                        )
                                     """)
 
                                     if(fileExists("${BENCHMARK_COMP_LOG}")){

--- a/scripts/netobserv.sh
+++ b/scripts/netobserv.sh
@@ -135,7 +135,10 @@ deploy_lokistack() {
   echo "====> Creating S3 secret for Loki"
   $SCRIPTS_DIR/deploy-loki-aws-secret.sh $S3_BUCKET_NAME
   sleep 60
-  oc wait --timeout=180s --for=condition=ready pod -l app.kubernetes.io/name=loki-operator -n openshift-operators-redhat
+  while :; do
+    oc wait --timeout=180s --for=condition=ready pod -l app.kubernetes.io/name=loki-operator -n openshift-operators-redhat && break
+    sleep 1
+  done
 
   echo "====> Determining LokiStack config"
   if [[ $LOKISTACK_SIZE == "1x.demo" ]]; then


### PR DESCRIPTION
While loop to wait for loki-operator and bug fix in Jenkinsfile

this should prevent errors like:
```
10-14 07:31:12.867  + oc wait --timeout=180s --for=condition=ready pod -l app.kubernetes.io/name=loki-operator -n openshift-operators-redhat
10-14 07:31:12.867  error: no matching resources found
```
and 
```
10-14 11:46:42.726  /home/jenkins/ws/workspace/ch-pipeline_netobserv-perf-tests@tmp/durable-202ebc20/script.sh.copy: line 4: syntax error near unexpected token `)'
```
latter causes comparison to fail and marking whole run as Unstable.