### PR TITLE
Adding rosa cli used for workers-scale

### DIFF
--- a/prow/Dockerfile
+++ b/prow/Dockerfile
@@ -5,5 +5,8 @@ LABEL vendor="Red Hat Inc." maintainer="OCP QE Team"
 RUN curl -sSL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux-amd64-rhel8.tar.gz | tar -xvzf -  &&\
     mv kubectl /bin 
 
+RUN curl -sSL $(curl -sSL https://api.github.com/repos/openshift/rosa/releases/latest | jq -r ".assets[] | select(.name == \"rosa_Linux_x86_64.tar.gz\") | .browser_download_url") | tar xvzf - &&\
+    mv rosa /bin
+
 RUN apt-get update && apt-get install -y gettext-base uuid-runtime jq openssh-client sshpass && \
     ln -s /bin/bash /usr/bin/bash && /usr/local/bin/python -m pip install --upgrade pip && pip install virtualenv jq


### PR DESCRIPTION
### Description
Adding rosa cli so that we can use it new kube-burner workers-scale workload

### Testing
Tested and verified in local. This will help fix this [job](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/58155/rehearse-58155-periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-rosa-4.16-nightly-x86-control-plane-24nodes/1849588907381886976)
```
root@59125f3ec335:/# rosa version
I: 1.2.46
I: Your ROSA CLI is up to date.
```