### PR TITLE
Do not count traffic returned from services in metrics + filter eth0

### DIFF
--- a/scripts/queries/netobserv_prometheus_queries.yaml
+++ b/scripts/queries/netobserv_prometheus_queries.yaml
@@ -23,7 +23,7 @@
   metricName: nWorkloadBytesProcessedPerMinuteNetobserv
 
 # total bytes processed from workload namespaces by cadvisor / other means
-- query: sum(rate(container_network_receive_bytes_total{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", namespace=~"node-density-heavy.*|ingress-perf|cluster-density.*"}[1m])*60)
+- query: sum(rate(container_network_receive_bytes_total{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", namespace=~"node-density-heavy.*|ingress-perf|cluster-density.*", interface="eth0"}[1m])*60)
   metricName: nWorkloadBytesProcessedPerMinuteCadvisor
 
 # total flows errored

--- a/scripts/queries/netobserv_prometheus_queries.yaml
+++ b/scripts/queries/netobserv_prometheus_queries.yaml
@@ -19,7 +19,7 @@
   metricName: nWorkloadFlowsProcessedPerMinuteTotals
 
 # total bytes processed from workload namespaces by netobserv
-- query: sum(rate(netobserv_workload_ingress_bytes_total{DstK8S_Namespace=~"node-density-heavy.*|ingress-perf|cluster-density.*",DstK8S_Type!="Service"}[1m])*60)
+- query: sum(rate(netobserv_workload_ingress_bytes_total{DstK8S_Namespace=~"node-density-heavy.*|ingress-perf|cluster-density.*",SrcK8S_Type!="Service",DstK8S_Type!="Service"}[1m])*60)
   metricName: nWorkloadBytesProcessedPerMinuteNetobserv
 
 # total bytes processed from workload namespaces by cadvisor / other means


### PR DESCRIPTION
- Traffic returned from service is duplicated with returned traffic from pods
- Filter on eth0 to avoid counting duplicates, cf comments in https://issues.redhat.com//browse/NETOBSERV-1954