### PR TITLE
Add bandwidth metrics to KPIs

### DIFF
--- a/scripts/queries/netobserv_touchstone_tolerancy_config.json
+++ b/scripts/queries/netobserv_touchstone_tolerancy_config.json
@@ -66,6 +66,32 @@
             },
             {
                 "filter": {
+                    "metric_name.keyword": "nWorkloadBytesProcessedPerMinuteNetobserv"
+                },
+                "buckets": [
+                    "metric_name.keyword"
+                ],
+                "aggregations": {
+                    "value": [
+                        "avg"
+                    ]
+                }
+            },
+            {
+                "filter": {
+                    "metric_name.keyword": "nWorkloadBytesProcessedPerMinuteCadvisor"
+                },
+                "buckets": [
+                    "metric_name.keyword"
+                ],
+                "aggregations": {
+                    "value": [
+                        "avg"
+                    ]
+                }
+            },
+            {
+                "filter": {
                     "metric_name.keyword": "nFlowsErroredTotals"
                 },
                 "buckets": [

--- a/scripts/queries/netobserv_touchstone_tolerancy_rules.yaml
+++ b/scripts/queries/netobserv_touchstone_tolerancy_rules.yaml
@@ -17,6 +17,12 @@
 - json_path: ["metric_name", "ebpfFlowsDroppedRatio", "metric_name", "*", "avg(value)"]
   tolerancy: 5
   max_failures: 0
+- json_path: ["metric_name", "nWorkloadBytesProcessedPerMinuteNetobserv", "metric_name", "*", "avg(value)"]
+  tolerancy: -10
+  max_failures: 0
+- json_path: ["metric_name", "nWorkloadBytesProcessedPerMinuteCadvisor", "metric_name", "*", "avg(value)"]
+  tolerancy: -10
+  max_failures: 0
 # CPU totals
 - json_path: ["metric_name", "cpuFLPTotals", "metric_name", "*", "avg(value)"]
   tolerancy: 10


### PR DESCRIPTION
Adding two metrics to KPIs:
- `nWorkloadBytesProcessedPerMinuteNetobserv`, which tells bandwidth captured by netobserv
- `nWorkloadBytesProcessedPerMinuteCadvisor`, which tells bandwidth captured via container metrics / cAdvisor

Both of them are interesting, as they can tell:
- That netobserv captured the expected amount of traffic, ie. not dropping too much, and checking correctness at the same time, ie. we haven't introduced a regression that miscounts bytes
- That the workload traffic isn't affected by netobserv (ie. a drop in cAdvisor metrics is an indication of performance regression with latency induced by netobserv)

Those metrics are more reliable than the number of flows for these goals because the workload bandwidth is supposed to be somewhat consistant across runs, whereas number of flows is a more arbitrary measure that is only loosely related to the actual measured bandwidth.