### PR TITLE
Taking out pod check

### DIFF
--- a/upgrade_scripts/upgrade.sh
+++ b/upgrade_scripts/upgrade.sh
@@ -186,5 +186,5 @@ if [ "X$scale" == "Xtrue" ]; then
 fi
 #wait 120s for all pod get ready
 sleep 120
-capture_failed_pods_after_upgrade
+#capture_failed_pods_after_upgrade
 exit 0 #upgrade succ and post-check succ

--- a/upgrade_scripts/upgrade.sh
+++ b/upgrade_scripts/upgrade.sh
@@ -61,7 +61,7 @@ echo "target version $taget_build_arr"
 echo "eus $eus"
 #wait 120s for all pod get ready
 sleep 120
-capture_failed_pods_before_upgrade
+#capture_failed_pods_before_upgrade
 python3 -c "import check_upgrade; check_upgrade.set_max_unavailable($maxUnavail)"
 echo ARCH_TYPE is $ARCH_TYPE
 if [[ $ARCH_TYPE == multi* ]];then


### PR DESCRIPTION
The pod check continuously fails but when it gets the pod logs the pods do not exist (go running/proper status) 

I don't think this step has been useful in finding any bugs and we can remove 

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/59872/rehearse-59872-periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-aws-4.17-nightly-x86-loaded-upgrade-from-4.16-loaded-upgrade-416to417-24nodes/1867598081550192640