### PR TITLE
use NOO container to get release info

### DIFF
--- a/scripts/nope.py
+++ b/scripts/nope.py
@@ -229,7 +229,7 @@ def get_netobserv_env_info():
     }
     base_commands = {
         "ocp": 'oc get co/authentication -o=jsonpath="{.status.versions[0].version}"',
-        "release": 'oc get pods -l app=netobserv-operator -o jsonpath="{.items[*].spec.containers[1].env[0].value}" -A',
+        "release": 'oc get pods -l app=netobserv-operator -o jsonpath="{.items[*].spec.containers[0].env[5].value}" -A',
         "arch": 'oc get node -o jsonpath="{.items[0].status.nodeInfo.architecture}"',
         "loki": 'oc get sub -n openshift-operators-redhat loki-operator -o jsonpath="{.status.currentCSV}"',
         "deploymentModel": 'oc get flowcollector -o jsonpath="{.items[*].spec.deploymentModel}" -n netobserv',

--- a/scripts/nope.py
+++ b/scripts/nope.py
@@ -229,7 +229,7 @@ def get_netobserv_env_info():
     }
     base_commands = {
         "ocp": 'oc get co/authentication -o=jsonpath="{.status.versions[0].version}"',
-        "release": 'oc get pods -l app=netobserv-operator -o jsonpath="{.items[*].spec.containers[0].env[5].value}" -A',
+        "release": "oc get pods -l app=netobserv-operator -o jsonpath=\"{.items[*].spec.containers[0].env[?(@.name=='OPERATOR_CONDITION_NAME')].value}\" -A",
         "arch": 'oc get node -o jsonpath="{.items[0].status.nodeInfo.architecture}"',
         "loki": 'oc get sub -n openshift-operators-redhat loki-operator -o jsonpath="{.status.currentCSV}"',
         "deploymentModel": 'oc get flowcollector -o jsonpath="{.items[*].spec.deploymentModel}" -n netobserv',


### PR DESCRIPTION
error in perf job: https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/netobserv-perf-tests/1477/consoleFull should be fixed 
```
01-23 17:40:47.138    File "/home/jenkins/ws/workspace/ch-pipeline_netobserv-perf-tests/ocp-qe-perfscale-ci/scripts/nope.py", line 895, in <module>
01-23 17:40:47.138      main()
01-23 17:40:47.138    File "/home/jenkins/ws/workspace/ch-pipeline_netobserv-perf-tests/ocp-qe-perfscale-ci/scripts/nope.py", line 586, in main
01-23 17:40:47.138      noo_start_time_epoch = get_epoch_from_iso(
01-23 17:40:47.138    File "/home/jenkins/ws/workspace/ch-pipeline_netobserv-perf-tests/ocp-qe-perfscale-ci/scripts/nope.py", line 86, in get_epoch_from_iso
01-23 17:40:47.138      utc_dt = datetime.strptime(isotime, "%Y-%m-%dT%H:%M:%SZ").replace(
01-23 17:40:47.138    File "/usr/lib64/python3.9/_strptime.py", line 568, in _strptime_datetime
01-23 17:40:47.138      tt, fraction, gmtoff_fraction = _strptime(data_string, format)
01-23 17:40:47.138    File "/usr/lib64/python3.9/_strptime.py", line 349, in _strptime
01-23 17:40:47.138      raise ValueError("time data %r does not match format %r" %
01-23 17:40:47.138  ValueError: time data '' does not match format '%Y-%m-%dT%H:%M:%SZ'
```

Tested locally:
```
$ ./nope.py --starttime 1737730686 --endtime 1737730687 --jenkins-job scale-ci/e2e-benchmarking-multibranch-pipeline/kube-burner-ocp --jenkins-build 2065 --uuid 3286fdd4-259e-4d6b-a91a-76b963a6b8ad --noo-bundle-version v0.0.0-main --jira NETOBSERV-2063 --dump-only
...
2025-01-24 09:59:45 memodi-mac root[2049] INFO Data written to /Users/memodi/workspaces/repos/ocp-qe-perfscale-ci/data/data_2025-01-24_09-59-45.json

$ jq '.netobserv_env.noo_start_time' /Users/memodi/workspaces/repos/ocp-qe-perfscale-ci/data/data_2025-01-24_09-59-45.json
"2025-01-24T14:58:04Z"

```
